### PR TITLE
Changing "no-cache" to "no-store" in Cache-Control header

### DIFF
--- a/app/com/m3/octoparts/cache/client/MemcachedClient.scala
+++ b/app/com/m3/octoparts/cache/client/MemcachedClient.scala
@@ -212,7 +212,7 @@ class MemcachedClient(
         resp
     }
 
-  private def mayCache(partResponse: PartResponse): Boolean = !partResponse.cacheControl.noCache
+  private def mayCache(partResponse: PartResponse): Boolean = !partResponse.cacheControl.noStore
 
   override def saveLater(partResponse: PartResponse, directive: CacheDirective): Future[Unit] = {
     if (mayCache(partResponse)) {

--- a/app/com/m3/octoparts/http/HttpResponseHandler.scala
+++ b/app/com/m3/octoparts/http/HttpResponseHandler.scala
@@ -41,7 +41,7 @@ class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[Http
     val etag = apacheResp.getHeaders(HeaderConstants.ETAG).headOption.map(_.getValue)
     // no need to attempt to parse the last-modified date.
     val lastModified = apacheResp.getHeaders(HeaderConstants.LAST_MODIFIED).headOption.map(_.getValue)
-    val (noCache, expiresAt) = parseCacheHeaders(apacheResp.getHeaders(HeaderConstants.CACHE_CONTROL))
+    val (noStore, expiresAt) = parseCacheHeaders(apacheResp.getHeaders(HeaderConstants.CACHE_CONTROL))
 
     HttpResponse(
       status = statusLine.getStatusCode,
@@ -50,7 +50,7 @@ class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[Http
       cookies = cookies,
       mimeType = mimeType,
       charset = charset,
-      cacheControl = CacheControl(noCache, expiresAt, etag, lastModified),
+      cacheControl = CacheControl(noStore, expiresAt, etag, lastModified),
       body = content
     )
   }
@@ -92,7 +92,7 @@ class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[Http
 
   def parseCacheHeaders(headers: Array[Header]): (Boolean, Option[Long]) = {
     val elts = headers.flatMap(_.getElements)
-    val noCache = elts.exists(_.getName == HeaderConstants.CACHE_CONTROL_NO_STORE)
+    val noStore = elts.exists(_.getName == HeaderConstants.CACHE_CONTROL_NO_STORE)
     val expiresAt = elts.collect {
       case elt if elt.getName == HeaderConstants.CACHE_CONTROL_MAX_AGE =>
         Try {
@@ -101,7 +101,7 @@ class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[Http
         }.toOption
     }.flatten.headOption
 
-    (noCache, expiresAt)
+    (noStore, expiresAt)
   }
 }
 

--- a/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
@@ -81,7 +81,7 @@ object CacheControl {
 }
 
 // Avoiding joda's DateTime to reduce models dependencies
-case class CacheControl(@BooleanBeanProperty noCache: Boolean = false,
+case class CacheControl(@BooleanBeanProperty noStore: Boolean = false,
                         @BeanProperty expiresAt: Option[Long] = None,
                         @BeanProperty etag: Option[String] = None,
                         @BeanProperty lastModified: Option[String] = None) {

--- a/test/com/m3/octoparts/cache/client/CacheClientSpec.scala
+++ b/test/com/m3/octoparts/cache/client/CacheClientSpec.scala
@@ -231,7 +231,7 @@ class CacheClientSpec extends FunSpec with Matchers with ScalaFutures with Event
     }
   }
 
-  it("should not cache a PartResponse that has the noCache flag set") {
+  it("should not cache a PartResponse that has the noStore flag set") {
     val cacheStuff = createCacheStuff
     val testee = cacheStuff.client
     val cacheDirective = CacheDirective("some part id 9", Seq.empty, Map.empty, Some(5 hours))
@@ -241,7 +241,7 @@ class CacheClientSpec extends FunSpec with Matchers with ScalaFutures with Event
       _ =>
         cacheStuff.latestVersionCache.updatePartVersion(cacheDirective.partId, version)
         val cacheKey = testee.PartCacheKeyFactory.tryApply(cacheDirective, testee.CombinedVersionLookup.knownVersions(cacheDirective)).get
-        val partResponse = PartResponse(cacheDirective.partId, cacheDirective.partId, cacheControl = CacheControl(noCache = true))
+        val partResponse = PartResponse(cacheDirective.partId, cacheDirective.partId, cacheControl = CacheControl(noStore = true))
         val cacheMissResp = testee.putIfAbsent(cacheDirective) {
           Future.successful(partResponse)
         }

--- a/test/com/m3/octoparts/http/HttpResponseHandlerSpec.scala
+++ b/test/com/m3/octoparts/http/HttpResponseHandlerSpec.scala
@@ -97,7 +97,7 @@ class HttpResponseHandlerSpec extends FunSpec with Matchers with BeforeAndAfter 
       val response = buildApacheResponse(HttpResponse(HttpStatus.SC_OK, "OK", headers = headers, body = Some("hello world")))
 
       val result = handler.handleResponse(response)
-      result.cacheControl.noCache should be(false)
+      result.cacheControl.noStore should be(false)
       result.cacheControl.expiresAt should be(Some(now + 3600 * 1000L))
     }
 
@@ -111,7 +111,7 @@ class HttpResponseHandlerSpec extends FunSpec with Matchers with BeforeAndAfter 
       val response = buildApacheResponse(HttpResponse(HttpStatus.SC_OK, "OK", headers = headers, body = Some("hello world")))
 
       val result = handler.handleResponse(response)
-      result.cacheControl.noCache should be(true)
+      result.cacheControl.noStore should be(true)
       result.cacheControl.expiresAt should be(None)
     }
 


### PR DESCRIPTION
Related issue:  https://github.com/m3dev/octoparts/issues/2

The Cache-Control directive by which backend API tells Octoparts not to store the response into  cache, is changed from "no-cache" to "no-store" according to the HTTP 1/1 spec.
