### PR TITLE
Fix revalidation logic to match the spec

### DIFF
--- a/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
+++ b/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
@@ -26,7 +26,7 @@ private[cache] object PartResponseCachingSupport {
   }
 
   private[cache] def shouldRevalidate(partResponse: PartResponse): Boolean = {
-    partResponse.retrievedFromCache && partResponse.cacheControl.hasExpired
+    partResponse.retrievedFromCache && partResponse.cacheControl.shouldRevalidate
   }
 }
 

--- a/app/com/m3/octoparts/cache/RichCacheControl.scala
+++ b/app/com/m3/octoparts/cache/RichCacheControl.scala
@@ -15,12 +15,14 @@ object RichCacheControl {
  */
 class RichCacheControl(val cacheControl: CacheControl) extends AnyVal {
 
+  def shouldRevalidate = cacheControl.noCache || (cacheControl.canRevalidate && hasExpired)
+
   /**
-   *
-   * @return true if there is no max-age header
+   * @return true if there is no max-age header, or there is a max-age header and it has expired
    */
-  def hasExpired = cacheControl.noCache || cacheControl.expiresAt.fold(true) {
-    _ <= DateTimeUtils.currentTimeMillis()
+  def hasExpired = cacheControl.expiresAt match {
+    case None => true // no max-age header, so always revalidate if we can
+    case Some(expiresAt) => expiresAt <= DateTimeUtils.currentTimeMillis()
   }
 
   def revalidationHeaders = Seq(

--- a/test/com/m3/octoparts/cache/RichCacheControlSpec.scala
+++ b/test/com/m3/octoparts/cache/RichCacheControlSpec.scala
@@ -1,22 +1,22 @@
-package com.m3.octoparts.aggregator
+package com.m3.octoparts.cache
 
-import org.scalatest._
-import org.joda.time.DateTimeUtils
-import com.m3.octoparts.model.CacheControl
 import com.m3.octoparts.cache.RichCacheControl._
+import com.m3.octoparts.model.CacheControl
+import org.joda.time.DateTimeUtils
+import org.scalatest._
 
-class CacheControlSpec extends FunSpec with Matchers with BeforeAndAfter {
+class RichCacheControlSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   before {
     DateTimeUtils.setCurrentMillisFixed(2222L)
   }
 
   it("is a good day to expire") {
+    // No max-age -> we should treat it as expired
     CacheControl(expiresAt = None).hasExpired shouldBe true
 
     CacheControl(expiresAt = Some(1111L)).hasExpired shouldBe true
     CacheControl(expiresAt = Some(3333L)).hasExpired shouldBe false
-
   }
 
   after {


### PR DESCRIPTION
Add tests for revalidation logic, matching the table on http://m3dev.github.io/octoparts/caching.html

Fix a regression caused by #8 (cached responses were being ignored unless there was an ETag)
