### PR TITLE
HTTP metrics require that names be unique

### DIFF
--- a/app/com/m3/octoparts/http/BasicHttpClient.scala
+++ b/app/com/m3/octoparts/http/BasicHttpClient.scala
@@ -40,7 +40,6 @@ class BasicHttpClient(
       .setSocketTimeout(socketTimeout.toMillis.toInt)
       .build()
 
-
     HttpClientBuilder
       .create
       .setRequestExecutor(BasicHttpClient.InstrumentedRequestExecutor)

--- a/test/com/m3/octoparts/http/BasicHttpClientSpec.scala
+++ b/test/com/m3/octoparts/http/BasicHttpClientSpec.scala
@@ -1,0 +1,17 @@
+package com.m3.octoparts.http
+
+import org.scalatest.{ FunSpec, Matchers }
+import org.scalatestplus.play.OneAppPerSuite
+
+import scala.concurrent.duration._
+
+class BasicHttpClientSpec extends FunSpec with Matchers with OneAppPerSuite {
+  it("should be able to create several instrumented clients") {
+    val clients = for (i <- 1 to 30) yield new BasicHttpClient(connectTimeout = i.seconds)
+    try {
+      clients.distinct should have size clients.size
+    } finally {
+      clients.foreach(_.close())
+    }
+  }
+}


### PR DESCRIPTION
`InstrumentedHttpClientConnectionManager` requires unique names or throws an Exception :

```
java.lang.IllegalArgumentException: A metric named org.apache.http.conn.HttpClientConnectionManager.available-connections already exists
    at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:91) ~[io.dropwizard.metrics.metrics-core-3.1.0.jar:3.1.0]
    at com.codahale.metrics.httpclient.InstrumentedHttpClientConnectionManager.<init>(InstrumentedHttpClientConnectionManager.java:57) ~[io.dropwizard.metrics.metrics-httpclient-3.1.0.jar:3.1.0]
```

Since our http clients can be destroyed and re-created, that leaves us with 2 options :
- a fully unique ID per http client (e.g. with a `UUID`)
- no ID and reuse the same `InstrumentedHttpClientConnectionManager`

This PR implements the second idea.
