### PR TITLE
Fix compilation error when BuildInfo includes git tag info

### DIFF
--- a/app/controllers/system/BuildInfoController.scala
+++ b/app/controllers/system/BuildInfoController.scala
@@ -17,7 +17,7 @@ object BuildInfoController extends Controller {
       "build_time_millis" -> BuildInfo.buildTime,
       "build_time_pretty" -> new LocalDateTime(BuildInfo.buildTime, DateTimeZone.forID("Asia/Tokyo")).toString("yyyy-MM-dd HH:mm:ss"),
       "git_branch" -> BuildInfo.gitBranch,
-      "git_tags" -> JsArray(BuildInfo.gitTags),
+      "git_tags" -> JsArray(BuildInfo.gitTags.map(JsString(_))),
       "git_head" -> JsString(BuildInfo.gitHEAD getOrElse "<unknown>")
     )
     Ok(json)


### PR DESCRIPTION
Whoopsy-daisy, the project doesn't compile if git HEAD is a tag!

```
[error]  found   : Seq[String]
[error]  required: Seq[play.api.libs.json.JsValue]
[error]       "git_tags" -> JsArray(BuildInfo.gitTags),
```

Unless you're on a tag, the auto-generated `BuildInfo` has an empty tag list with no type declaration, so it compiles fine.
