### PR TITLE
Rework the AggregateResponse enrichments

### DIFF
--- a/scala-ws-client/src/main/scala/com/m3/octoparts/ws/AggregateResponseEnrichment.scala
+++ b/scala-ws-client/src/main/scala/com/m3/octoparts/ws/AggregateResponseEnrichment.scala
@@ -13,7 +13,7 @@ import scala.util.{ Failure, Success, Try }
 
 object AggregateResponseEnrichment {
 
-  case class OctopartsException(errors: Seq[String]) extends RuntimeException(errors.mkString(SystemUtils.LINE_SEPARATOR))
+  case class OctopartsException(partResponse: PartResponse) extends RuntimeException(partResponse.errors.mkString(SystemUtils.LINE_SEPARATOR))
 
   private val logger = Logger("com.m3.octoparts.AggregateResponseEnrichment")
 
@@ -47,7 +47,7 @@ object AggregateResponseEnrichment {
      */
     def tryContentsIfNoError: Try[String] = {
       printWarnings()
-      if (part.errors.isEmpty) tryContents else Failure(OctopartsException(part.errors))
+      if (part.errors.isEmpty) tryContents else Failure(OctopartsException(part))
     }
 
     /**
@@ -83,7 +83,7 @@ object AggregateResponseEnrichment {
   }
 
   /**
-   * Convenience methods to make it easier to work with [[com.m3.octoparts.model.AggregateResponse]]
+   * Convenience methods to make it easier to work with [[AggregateResponse]]
    */
   implicit class RichAggregateResponse(val aggResp: AggregateResponse) extends AnyVal {
 
@@ -118,6 +118,10 @@ object AggregateResponseEnrichment {
       case Success(a) => Some(a)
       case Failure(failure) =>
         logger.warn(s"Object not retrievable from part response: $id", failure)
+        failure match {
+          case OctopartsException(pr) => logger.debug(s"Part response: $pr")
+          case _ =>
+        }
         None
     }
 

--- a/scala-ws-client/src/main/scala/com/m3/octoparts/ws/AggregateResponseEnrichment.scala
+++ b/scala-ws-client/src/main/scala/com/m3/octoparts/ws/AggregateResponseEnrichment.scala
@@ -3,17 +3,68 @@ package com.m3.octoparts.ws
 import java.io.IOException
 
 import com.m3.octoparts.model.{ AggregateResponse, PartResponse }
-import org.apache.commons.lang3.StringUtils
+import org.apache.commons.lang3.{ StringUtils, SystemUtils }
 import play.api.Logger
 import play.api.data.validation.ValidationError
 import play.api.i18n.Messages
-import play.api.libs.json.{ JsPath, JsValue, Json, Reads }
+import play.api.libs.json._
 
-import scala.util.{ Try, Success, Failure }
+import scala.util.{ Failure, Success, Try }
 
 object AggregateResponseEnrichment {
 
+  case class OctopartsException(errors: Seq[String]) extends RuntimeException(errors.mkString(SystemUtils.LINE_SEPARATOR))
+
   private val logger = Logger("com.m3.octoparts.AggregateResponseEnrichment")
+
+  implicit class RichPartResponse(val part: PartResponse) extends AnyVal {
+
+    def fullId: String = if (part.id == part.partId) part.id else s"${part.partId} (${part.id})"
+
+    def tryContents: Try[String] = {
+      part.contents match {
+        case Some(contents) if StringUtils.isNotBlank(contents) => Success(contents)
+        case _ => Failure(new IOException("No content"))
+      }
+    }
+
+    def printWarnings(): Unit = for (warning <- part.warnings) {
+      logger.warn(s"In part $fullId: $warning")
+    }
+
+    def tryContentsIfNoError: Try[String] = {
+      printWarnings()
+      if (part.errors.isEmpty) tryContents else Failure(OctopartsException(part.errors))
+    }
+
+    /**
+     * Will return a failure if
+     * - the part has no content
+     * - the JSON parsing fails (e.g. the content is not JSON, or the JSON is broken in some way)
+     * - the JSON deserialization fails (i.e. the JSON is valid, but cannot be deserialized into an [[A]])
+     *
+     * @tparam A the result type, i.e. the type of the JSON-serialized object
+     */
+    def tryJson[A: Reads]: Try[A] = {
+      for {
+        contents <- tryContents
+        json <- Try(Json.parse(contents))
+        a <- mapJson(json)
+      } yield {
+        a
+      }
+    }
+
+    def tryJsonIfNoError[A: Reads]: Try[A] = {
+      for {
+        contents <- tryContentsIfNoError
+        json <- Try(Json.parse(contents))
+        a <- mapJson(json)
+      } yield {
+        a
+      }
+    }
+  }
 
   /**
    * Convenience methods to make it easier to work with [[com.m3.octoparts.model.AggregateResponse]]
@@ -25,7 +76,7 @@ object AggregateResponseEnrichment {
      *
      * Note that an appropriate [[play.api.libs.json.Reads]] must be available in implicit scope.
      *
-     * Will return None if:
+     * Will return a Failure if:
      * - a part with the given ID is not present in the response
      * - the part has no content
      * - the JSON parsing fails (e.g. the content is not JSON, or the JSON is broken in some way)
@@ -35,53 +86,55 @@ object AggregateResponseEnrichment {
      * - The method does not check the status code of the response or the presence of error messages.
      *
      * @param id the part request unique id (or partId if the part request did not specify an ID)
-     * @param recoverWith can be customized to return something even if JSON extraction failed.
      * @tparam A the result type, i.e. the type of the JSON-serialized object
-     * @return the object, or None if it could not be found and deserialized for some reason.
+     * @return the object, or Failure if it could not be found and deserialized for some reason.
      */
-    def getJsonPart[A: Reads](id: String, recoverWith: (String, Throwable) => Option[A] = warnFailure): Option[A] = {
-      tryJsonPart[A](id) match {
-        case Failure(e) => recoverWith(id, e)
-        case Success(v) => Some(v)
+    def tryJsonPart[A: Reads](id: String): Try[A] = tryFindPart(id).flatMap(_.tryJsonIfNoError)
+
+    /**
+     * Logs any errors from [[tryJsonPart]] and collapses to an Option
+     *
+     * @param id
+     * @tparam A
+     * @return
+     */
+    def getJsonPart[A: Reads](id: String): Option[A] = tryJsonPart(id) match {
+      case Success(a) => Some(a)
+      case Failure(failure) =>
+        logger.warn(s"Object not retrievable from part response: $id", failure)
+        None
+    }
+
+    def getJsonPartOrElse[A: Reads](id: String, default: => A): A = getJsonPart(id).getOrElse(default)
+
+    /**
+     * Deserializes like [[tryJsonPart]], but will try instead to deserialize to an [[E]] if the part response contained errors
+     * @tparam A
+     * @tparam E
+     */
+    def getJsonPartOrError[A: Reads, E: Reads](id: String): Either[Option[E], A] = tryFindPart(id) match {
+      case Failure(noPart) => {
+        logger.warn("Could not retrieve object from response", noPart)
+        Left(None)
+      }
+      case Success(part) => part.tryJsonIfNoError[A] match {
+        case Success(a) => Right(a)
+        case Failure(_) => {
+          part.tryJson[E] match {
+            case Success(e) => Left(Some(e))
+            case Failure(failureE) =>
+              logger.warn("Could not deserialize error", failureE)
+              Left(None)
+          }
+        }
       }
     }
 
-    def getJsonPartOrElse[A: Reads](id: String, default: => A): A = getJsonPart[A](id).getOrElse(default)
-
-    private def tryJsonPart[A: Reads](id: String): Try[A] = {
-      for {
-        part <- findPart(id)
-        contents <- getContents(id, part)
-        json <- Try(Json.parse(contents))
-        a <- mapJson(json)
-      } yield {
-        a
+    def tryFindPart(id: String): Try[PartResponse] = {
+      aggResp.findPart(id) match {
+        case None => Failure(new NoSuchElementException(s"part with id=$id not found"))
+        case Some(part) => Success(part)
       }
-    }
-
-    private def findPart(id: String): Try[PartResponse] = {
-      aggResp.findPart(id).fold[Try[PartResponse]] {
-        Failure(new IllegalArgumentException(s"part with id=$id not found"))
-      }(Success.apply)
-    }
-  }
-
-  private def getContents(id: String, part: PartResponse): Try[String] = {
-    part.contents match {
-      case Some(contents) if StringUtils.isNotBlank(contents) => {
-        // print remaining errors
-        printErrors(id, part)
-        Success(contents)
-      }
-      case _ => Failure(new IOException(part.errors.headOption.getOrElse("No content")))
-    }
-  }
-
-  private def printErrors(id: String, part: PartResponse): Unit = {
-    for {
-      error <- part.errors
-    } {
-      logger.warn(s"Error in part with id: $id, error: $error")
     }
   }
 
@@ -102,11 +155,5 @@ object AggregateResponseEnrichment {
         s"error at: $jsPath reason: $validationErrorMsg"
       }
     }.mkString("; ")
-  }
-
-  val warnFailure: (String, Throwable) => Option[Nothing] = {
-    (id, failure) =>
-      logger.warn(s"Object not retrievable from part response: $id", failure)
-      None
   }
 }

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichAggregateResponseSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichAggregateResponseSpec.scala
@@ -1,28 +1,42 @@
 package com.m3.octoparts.ws
 
+import java.io.IOException
+
 import com.m3.octoparts.ws.AggregateResponseEnrichment._
 import com.m3.octoparts.model.{ PartResponse, ResponseMeta, AggregateResponse }
 import org.scalatest.{ Matchers, FlatSpec }
 import play.api.libs.json.Json
 import scala.concurrent.duration._
+import scala.util.Success
 
 class RichAggregateResponseSpec extends FlatSpec with Matchers {
 
   behavior of "#getJsonPart"
 
   case class Frisk(mints: Int, mintiness: String)
-  implicit val reads = Json.reads[Frisk]
+  object Frisk {
+    implicit val _ = Json.reads[Frisk]
+  }
+  case class Error(msg: String)
+  object Error {
+    implicit val _ = Json.reads[Error]
+  }
 
   val aggResp = AggregateResponse(ResponseMeta("foo", 123.millis), Seq(
     PartResponse("myJsonPart", "myJsonPart", statusCode = Some(200), contents = Some("""{"mints": 50, "mintiness": "very minty"}""")),
     PartResponse("invalidJsonPart", "invalidJsonPart", statusCode = Some(200), contents = Some("""{"error": "something went wrong!"}""")),
     PartResponse("brokenJsonPart", "brokenJsonPart", statusCode = Some(200), contents = Some("""{"mints": }""")),
     PartResponse("noContentPart", "noContentPart", statusCode = Some(200), contents = None),
-    PartResponse("errorPart", "errorPart", statusCode = Some(200), contents = Some("""{"mints": 50, "mintiness": "very minty"}"""), errors = Seq("boo!")),
+    PartResponse("errorPart", "errorPart", statusCode = Some(500), contents = Some("""{"mints": 50, "mintiness": "very minty"}"""), errors = Seq("boo1", "boo2")),
+    PartResponse("errorPartWithValidError", "errorPartWithValidError", statusCode = Some(400), contents = Some("""{"msg": "bad request"}"""), errors = Seq("That was a bad request.")),
+    PartResponse("errorPartWithBrokenError", "errorPartWithBrokenError", statusCode = Some(500), contents = Some("Internal Server Error"), errors = Seq("boo1", "boo2")),
     PartResponse("differentStatusCodePart", "differentStatusCodePart", statusCode = Some(404), contents = Some("""{"mints": 50, "mintiness": "very minty"}"""))
   ))
   val richAggResp = new RichAggregateResponse(aggResp)
 
+  it should "successfully find a PartResponse by partId and deserialize its contents" in {
+    richAggResp.tryJsonPart[Frisk]("myJsonPart") should be(Success(Frisk(50, "very minty")))
+  }
   it should "find a PartResponse by partId and deserialize its contents" in {
     richAggResp.getJsonPart[Frisk]("myJsonPart") should be(Some(Frisk(50, "very minty")))
   }
@@ -35,18 +49,19 @@ class RichAggregateResponseSpec extends FlatSpec with Matchers {
   it should "return None if the part has no content" in {
     richAggResp.getJsonPart[Frisk]("noContentPart") should be(None)
   }
-  it should "deserialize and return the result even if the part has error messages" in {
-    richAggResp.getJsonPart[Frisk]("errorPart") should be(Some(Frisk(50, "very minty")))
+  it should "give up on deserialization if the result has error messages" in {
+    richAggResp.getJsonPart[Frisk]("errorPart") should be(None)
+  }
+  it should "deserialize errors if asked nicely" in {
+    richAggResp.getJsonPartOrError[Frisk, Error]("errorPartWithValidError") should be(Left(Some(Error("bad request"))))
+  }
+  it should "fail to deserialize errors even if asked nicely" in {
+    richAggResp.getJsonPartOrError[Frisk, Error]("errorPartWithBrokenError") should be(Left(None))
   }
   it should "return None if the part does not exist" in {
     richAggResp.getJsonPart[Frisk]("whoAreYou") should be(None)
   }
   it should "deserialize and return the result even if the status code is not 200" in {
     richAggResp.getJsonPart[Frisk]("differentStatusCodePart") should be(Some(Frisk(50, "very minty")))
-  }
-  it should "use a custom recovery scheme" in {
-    richAggResp.getJsonPart[Frisk]("brokenJsonPart", { (id, failure) => Some(Frisk(0, failure.toString)) }) should matchPattern {
-      case Some(Frisk(0, mintiness)) if mintiness.contains("Exception") =>
-    }
   }
 }

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartResponseSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartResponseSpec.scala
@@ -1,7 +1,7 @@
 package com.m3.octoparts.ws
 
 import com.m3.octoparts.model.PartResponse
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{ FunSpec, Matchers }
 
 import scala.util.Success
 
@@ -15,11 +15,11 @@ class RichPartResponseSpec extends FunSpec with Matchers {
   }
 
   describe("#tryContentsIfNoError") {
-    it ("should stop if there are errors") {
+    it("should stop if there are errors") {
       val partResponse = PartResponse("partId", "id", contents = Some("woot!"), errors = Seq("Oops"))
       partResponse.tryContentsIfNoError.isFailure shouldBe true
     }
-    it ("should not stop for mere warnings") {
+    it("should not stop for mere warnings") {
       val partResponse = PartResponse("partId", "id", contents = Some("woot!"), warnings = Seq("Oops"))
       partResponse.tryContentsIfNoError shouldBe Success("woot!")
     }

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartResponseSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartResponseSpec.scala
@@ -1,0 +1,27 @@
+package com.m3.octoparts.ws
+
+import com.m3.octoparts.model.PartResponse
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.util.Success
+
+class RichPartResponseSpec extends FunSpec with Matchers {
+  import AggregateResponseEnrichment.RichPartResponse
+  describe("#tryContents") {
+    it("should fail on blank contents") {
+      val partResponse = PartResponse("partId", "id", contents = Some(" \r\n "))
+      partResponse.tryContents.isFailure shouldBe true
+    }
+  }
+
+  describe("#tryContentsIfNoError") {
+    it ("should stop if there are errors") {
+      val partResponse = PartResponse("partId", "id", contents = Some("woot!"), errors = Seq("Oops"))
+      partResponse.tryContentsIfNoError.isFailure shouldBe true
+    }
+    it ("should not stop for mere warnings") {
+      val partResponse = PartResponse("partId", "id", contents = Some("woot!"), warnings = Seq("Oops"))
+      partResponse.tryContentsIfNoError shouldBe Success("woot!")
+    }
+  }
+}

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/Sample.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/Sample.scala
@@ -28,36 +28,41 @@ object Sample {
   // Create a client
   val octoClient = new OctoClient("http://octoparts/", clientTimeout = 1.second)
 
-  // Build an AggregateRequest to send to Octoparts
-  val aggregateRequest = AggregateRequest(
-    requestMeta = RequestMeta(
+  implicit object rmb extends RequestMetaBuilder[Int] {
+    def apply(userId: Int) = RequestMeta(
       // Most of these fields are optional
       id = UUID.randomUUID().toString,
       serviceId = Some("frontend"),
-      userId = Some("123"),
+      userId = Some(userId.toString),
       requestUrl = Some("http://www.m3.com/foo"),
       timeout = Some(500.millis)
-    ),
-    requests = Seq(
-      // A list of the endpoints you want to call, with parameters to send
-      PartRequest(partId = "UserProfile", params = Seq(PartRequestParam("uid", "123"))),
-      PartRequest(partId = "LatestNews", params = Seq(PartRequestParam("limit", "10")))
     )
+  }
+
+  // Prepare part requests to send to Octoparts
+  val requests = Seq(
+    // A list of the endpoints you want to call, with parameters to send
+    PartRequest(partId = "UserProfile", params = Seq(PartRequestParam("uid", "123"))),
+    PartRequest(partId = "LatestNews", params = Seq(PartRequestParam("limit", "10")))
   )
 
-  // Send the request, get back a Future
-  val fResp: Future[AggregateResponse] = octoClient.invoke(aggregateRequest)
+  // Send the requests, get back a Future
+  val fResp: Future[AggregateResponse] = octoClient.invoke(123, requests)
 
   fResp.map { aggregateResponse =>
 
     // Result will be None if:
     // - Octoparts did not return a response for this endpoint (e.g. because the endpoint was too slow to respond)
+    // - the response contained errors
     // - the response could not be deserialized into a UserProfile
     val userProfile: Option[UserProfile] = aggregateResponse.getJsonPart[UserProfile]("UserProfile")
 
     // Get the list of latest news articles, falling back to an empty list in case of error
     val latestNews: Seq[NewsArticle] = aggregateResponse.getJsonPartOrElse[Seq[NewsArticle]]("LatestNews", default = Nil)
 
+    // Get the list of latest news article, falling back to another json model in case of error
+    val userNews: Either[Option[UserProfile], NewsArticle] = aggregateResponse.getJsonPartOrError[NewsArticle, UserProfile]("UserNews")
+    userNews.right.toOption == aggregateResponse.getJsonPart[NewsArticle]("UserNews")
     // Do stuff with the user profile and the list of news articles ...
 
   }


### PR DESCRIPTION
Fixes #90 

- Added a `RichPartResponse` and useful methods to it
- removed the `recoverWith` scheme. Users should prefer `tryJsonPart`.
- Print warnings