### PR TITLE
When returning local content, the part request ID should be kept

### DIFF
--- a/app/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupport.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupport.scala
@@ -21,7 +21,7 @@ trait PartResponseLocalContentSupport extends PartRequestServiceBase {
   private def createPartResponse(ci: HttpPartConfig,
                                  partRequestInfo: PartRequestInfo) = PartResponse(
     ci.partId,
-    id = ci.partId,
+    id = partRequestInfo.partRequestId,
     statusCode = Some(200),
     contents = ci.localContents,
     retrievedFromLocalContents = true

--- a/test/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupportSpec.scala
+++ b/test/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupportSpec.scala
@@ -49,7 +49,7 @@ class PartResponseLocalContentSupportSpec extends FlatSpec
       resp should not be theSameInstanceAs(partResponseFromSuper)
       resp should be(PartResponse(
         partId = "something",
-        id = "something",
+        id = "id",
         statusCode = Some(200),
         contents = Some("{}"),
         retrievedFromLocalContents = true


### PR DESCRIPTION
Fixes #93 

cc @ntaro 
review by @lloydmeta 