### PR TITLE
Feature/localcontents fallback, closes #76

### DIFF
--- a/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
+++ b/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
@@ -20,7 +20,7 @@ class SimpleHttpHandlerFactory(httpClientPool: HttpClientPool)(
       config.method,
       config.additionalValidStatuses,
       config.parameters,
-      HystrixExecutor(config.hystrixConfigItem)
+      HystrixExecutor(config)
     )
   }
 

--- a/app/com/m3/octoparts/http/HttpResponse.scala
+++ b/app/com/m3/octoparts/http/HttpResponse.scala
@@ -16,6 +16,7 @@ import com.m3.octoparts.model.{ CacheControl, Cookie }
  * @param cookies maybe a Sequence of cookies
  * @param mimeType maybe a MimeType
  * @param charset maybe a Charset
+ * @param fromFallback whether or not this HTTP response from a fallback
  * @param body maybe a body String
  */
 case class HttpResponse(
@@ -26,4 +27,5 @@ case class HttpResponse(
   mimeType: Option[String] = None,
   charset: Option[String] = None,
   cacheControl: CacheControl = CacheControl.NotSet,
+  fromFallback: Boolean = false,
   body: Option[String] = None)

--- a/app/com/m3/octoparts/hystrix/HystrixExecutor.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixExecutor.scala
@@ -1,8 +1,7 @@
 package com.m3.octoparts.hystrix
 
-import com.m3.octoparts.model.config.{ HttpPartConfig, HystrixConfig }
+import com.m3.octoparts.model.config.HttpPartConfig
 import com.netflix.hystrix.HystrixCommand
-import com.netflix.hystrix.HystrixCommand.Setter
 
 import scala.concurrent.Future
 

--- a/app/com/m3/octoparts/hystrix/HystrixExecutor.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixExecutor.scala
@@ -1,43 +1,29 @@
 package com.m3.octoparts.hystrix
 
-import com.m3.octoparts.model.config.HystrixConfig
+import com.m3.octoparts.model.config.{ HttpPartConfig, HystrixConfig }
 import com.netflix.hystrix.HystrixCommand
 import com.netflix.hystrix.HystrixCommand.Setter
 
 import scala.concurrent.Future
 
-/**
- * Companion object for instantiating HystrixExecutors
- */
-object HystrixExecutor extends HystrixSetterSupport {
-
-  /**
-   * Instantiates and returns a HystrixExecutor that you can call #future on, passing
-   * in a block you want to run asynchronously and backed by Hystrix
-   */
-  def apply(hystrixConfig: HystrixConfig): HystrixExecutor = new HystrixExecutor(setter(hystrixConfig))
-}
-
-/**
- * This should be instantiated via the factory method in the companion object.
- *
- * Serves to simplify wrapping any synchronous piece of code inside
- * a HystrixCommand. Mostly delegates the work to Hystrix
- *
- * @param setter HystrixCommand Setter.
- */
-class HystrixExecutor(setter: Setter) {
+case class HystrixExecutor(config: HttpPartConfig) extends HystrixSetterSupport {
 
   /**
    * Returns a Future result of the block passed, run within the context
    * of the Hystrix configuration settings that this HystrixExecutor object
    * was instantiated with.
    *
-   * @return Future[R]
+   * Note that if withFallback is passed, it will always be used.
+   *
+   * @param f The function to be made async
+   * @param fallbackTransform How to transform the local contents into a fallback.
+   *                          This will not be called if the HystrixConfig in HttpPartConfig has
+   *                          localContentsAsFallback set to false
    */
-  def future[T](f: => T): Future[T] = {
-    new HystrixCommand[T](setter) with HystrixFutureSupport[T] {
+  def future[T](f: => T, fallbackTransform: Option[String] => T): Future[T] = {
+    new HystrixCommand[T](setter(config.hystrixConfigItem)) with HystrixFutureSupport[T] {
       override def run = f
+      override def getFallback: T = fallbackTransform(config.localContents)
     }.future
   }
 }

--- a/app/com/m3/octoparts/hystrix/HystrixSetterSupport.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixSetterSupport.scala
@@ -23,6 +23,6 @@ trait HystrixSetterSupport {
       andThreadPoolPropertiesDefaults(threadPoolProperties).
       andCommandPropertiesDefaults(HystrixCommandProperties.Setter().
         withExecutionIsolationThreadTimeoutInMilliseconds(config.timeoutInMs.toInt).
-        withFallbackEnabled(false))
+        withFallbackEnabled(config.localContentsAsFallback))
   }
 }

--- a/app/com/m3/octoparts/model/config/HystrixConfig.scala
+++ b/app/com/m3/octoparts/model/config/HystrixConfig.scala
@@ -18,6 +18,7 @@ object HystrixConfig {
       threadPoolConfig = ThreadPoolConfig.toJsonModel(config.threadPoolConfig.get),
       commandKey = config.commandKey,
       commandGroupKey = config.commandGroupKey,
+      localContentsAsFallback = config.localContentsAsFallback,
       timeout = config.timeoutInMs.millis
     )
   }
@@ -28,6 +29,7 @@ object HystrixConfig {
       commandKey = config.commandKey,
       commandGroupKey = config.commandGroupKey,
       timeoutInMs = config.timeout.toMillis,
+      localContentsAsFallback = config.localContentsAsFallback,
       createdAt = DateTime.now,
       updatedAt = DateTime.now
     )
@@ -36,8 +38,6 @@ object HystrixConfig {
 
 /**
  * Holds the Hystrix Configuration data for a given dependency
- *
- * TODO: Link to a ThreadPoolConfig
  */
 case class HystrixConfig(
     id: Option[Long] = None, // None means the HystrixConfig is new (not inserted yet)
@@ -48,6 +48,7 @@ case class HystrixConfig(
     commandKey: String,
     commandGroupKey: String,
     timeoutInMs: Long = HystrixConfig.defaultTimeout,
+    localContentsAsFallback: Boolean,
     createdAt: DateTime,
     updatedAt: DateTime) extends ConfigModel[HystrixConfig] {
 

--- a/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
@@ -19,6 +19,7 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
     "threadPoolConfigId" -> SkinnyParamType.Long,
     "commandKey" -> SkinnyParamType.String,
     "commandGroupKey" -> SkinnyParamType.String,
+    "localContentsAsFallback" -> SkinnyParamType.Boolean,
     "timeoutInMs" -> SkinnyParamType.Long
   )
 
@@ -56,6 +57,7 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
     commandKey = rs.get(n.commandKey),
     commandGroupKey = rs.get(n.commandGroupKey),
     timeoutInMs = rs.get(n.timeoutInMs),
+    localContentsAsFallback = rs.get(n.localContentsAsFallback),
     createdAt = rs.get(n.createdAt),
     updatedAt = rs.get(n.updatedAt))
 

--- a/app/views/part/edit.scala.html
+++ b/app/views/part/edit.scala.html
@@ -150,7 +150,7 @@
                 <label for="commandKey" class="col-sm-2 control-label">@Messages("parts.hystrix.commandKey")</label>
                 <div class="row">
                     <div class="col-sm-5">
-                        @helper.inputText(form("commandKey"), 'class -> "form-control validate[required]")
+                        @helper.inputText(form("hystrixConfig.commandKey"), 'class -> "form-control validate[required]")
                     </div>
                 </div>
             </div>
@@ -159,7 +159,7 @@
                 <label for="commandGroupKey" class="col-sm-2 control-label">@Messages("parts.hystrix.commandGroupKey")</label>
                 <div class="row">
                     <div class="col-sm-5">
-                        @helper.inputText(form("commandGroupKey"), 'class -> "form-control validate[required]")
+                        @helper.inputText(form("hystrixConfig.commandGroupKey"), 'class -> "form-control validate[required]")
                     </div>
                 </div>
             </div>
@@ -168,7 +168,16 @@
                 <label for="timeoutInMs" class="col-sm-2 control-label">@Messages("parts.hystrix.timeoutInMs.label")</label>
                 <div class="row">
                     <div class="col-sm-5">
-                        @helper.inputText(form("timeoutInMs"), 'class -> "form-control validate[required]")
+                        @helper.inputText(form("hystrixConfig.timeoutInMs"), 'class -> "form-control validate[required]")
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="commandKey" class="col-sm-2 control-label">@Messages("parts.hystrix.localContentsAsFallback")</label>
+                <div class="row">
+                    <div class="col-sm-5">
+                    @helper.checkbox(form("hystrixConfig.localContentsAsFallback"), 'class -> "form-control validate[required]")
                     </div>
                 </div>
             </div>
@@ -178,7 +187,7 @@
                 <div class="row">
                     <div class="col-sm-5">
                         @helper.select(
-                            field = form("threadPoolConfigId"),
+                            field = form("hystrixConfig.threadPoolConfigId"),
                             options = threadPoolConfigs.map(tpc => (tpc.id.get.toString, s"${tpc.threadPoolKey} (core size: ${tpc.coreSize})")),
                             args = 'class -> "form-control validate[required]")
                     </div>

--- a/app/views/part/edit.scala.html
+++ b/app/views/part/edit.scala.html
@@ -193,6 +193,33 @@
                     </div>
                 </div>
             </div>
+
+            <fieldset>
+                <legend>@Messages("parts.section.localContents")</legend>
+
+                <div class="form-group">
+                    <label for="localContentsEnabled" class="col-sm-2 control-label">@Messages("parts.localContents.always")</label>
+                    <div class="row">
+                        <div class="col-sm-5">
+                        @helper.checkbox(form("localContentsConfig.enabled"))
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-group" id="localContents">
+                    <label for="localContents" class="col-sm-2 control-label">@Messages("parts.localContents.contents")</label>
+                    <div class="row">
+                        <div class="col-sm-5">
+                        @helper.textarea(form("localContentsConfig.contents"),
+                            'class -> "form-control",
+                            'rows -> 12,
+                            Symbol("data-placement") -> "top")
+                        </div>
+                        <button id="jsonValidateButton" type="button" class="btn btn-default">@Messages("parts.localContents.validateJson")</button>
+                    </div>
+                </div>
+            </fieldset>
+
         </fieldset>
 
         <fieldset>
@@ -268,32 +295,6 @@
                         @helper.inputText(form("alertMailRecipients"), 'class -> "form-control")
                         <p class="help-block">@Messages("parts.alertMail.recipients.help")</p>
                     </div>
-                </div>
-            </div>
-        </fieldset>
-
-        <fieldset>
-            <legend>@Messages("parts.section.localContents")</legend>
-
-            <div class="form-group">
-                <label for="localContentsEnabled" class="col-sm-2 control-label">@Messages("parts.localContents.enabled")</label>
-                <div class="row">
-                    <div class="col-sm-5">
-                    @helper.checkbox(form("localContentsConfig.enabled"))
-                    </div>
-                </div>
-            </div>
-
-            <div class="form-group" id="localContents">
-                <label for="localContents" class="col-sm-2 control-label">@Messages("parts.localContents.contents")</label>
-                <div class="row">
-                    <div class="col-sm-5">
-                    @helper.textarea(form("localContentsConfig.contents"),
-                        'class -> "form-control",
-                        'rows -> 12,
-                        Symbol("data-placement") -> "top")
-                    </div>
-                    <button id="jsonValidateButton" type="button" class="btn btn-default">@Messages("parts.localContents.validateJson")</button>
                 </div>
             </div>
         </fieldset>

--- a/app/views/part/show.scala.html
+++ b/app/views/part/show.scala.html
@@ -117,6 +117,14 @@
                 <dd>@Messages("parts.hystrix.none.body")</dd>
             }
         }
+
+        <h3>@Messages("parts.section.localContents")</h3>
+
+        <dt>@Messages("parts.localContents.always")</dt>
+        <dd>@part.config.localContentsEnabled</dd>
+        <dt>@Messages("parts.localContents.contents")</dt>
+        <dd>@part.config.localContents.getOrElse("")</dd>
+
     </dl>
 
     <hr/>
@@ -153,11 +161,4 @@
     }
 
     <hr/>
-    <h2>@Messages("parts.section.localContents")</h2>
-    <dl>
-        <dt>@Messages("parts.localContents.enabled")</dt>
-        <dd>@part.config.localContentsEnabled</dd>
-        <dt>@Messages("parts.localContents.contents")</dt>
-        <dd>@part.config.localContents.getOrElse("")</dd>
-    </dl>
 }

--- a/app/views/part/show.scala.html
+++ b/app/views/part/show.scala.html
@@ -107,6 +107,8 @@
                 <dd>@hystrixConfigItem.commandGroupKey</dd>
                 <dt>@Messages("parts.hystrix.timeoutInMs")</dt>
                 <dd>@hystrixConfigItem.timeoutInMs</dd>
+                <dt>@Messages("parts.hystrix.localContentsAsFallback")</dt>
+                <dd>@hystrixConfigItem.localContentsAsFallback</dd>
                 <dt>@Messages("threadPools.key")</dt>
                 <dd>@hystrixConfigItem.threadPoolConfigItem.threadPoolKey</dd>
             }
@@ -152,9 +154,10 @@
 
     <hr/>
     <h2>@Messages("parts.section.localContents")</h2>
-    @if(part.config.localContentsEnabled) {
-        <pre>@part.config.localContents.orNull</pre>
-    } else {
-        <p>@Messages("parts.localContents.disabled")</p>
-    }
+    <dl>
+        <dt>@Messages("parts.localContents.enabled")</dt>
+        <dd>@part.config.localContentsEnabled</dd>
+        <dt>@Messages("parts.localContents.contents")</dt>
+        <dd>@part.config.localContents.getOrElse("")</dd>
+    </dl>
 }

--- a/conf/db/migration/default/V4__Add_fallback.sql
+++ b/conf/db/migration/default/V4__Add_fallback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hystrix_config ADD COLUMN local_contents_as_fallback boolean DEFAULT false NOT NULL;

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -45,6 +45,7 @@ parts.hystrix.commandKey=Command key
 parts.hystrix.commandGroupKey=Command group
 parts.hystrix.timeoutInMs=Timeout
 parts.hystrix.timeoutInMs.label=Timeout (ms)
+parts.hystrix.localContentsAsFallback=Use local contents as fallback
 parts.hystrix.none.title=Error!
 parts.hystrix.none.body=The Hystrix configuration is missing.
 parts.section.cache=Cache settings

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -73,6 +73,7 @@ parts.alertMail.selectOne=At least one of these must be selected
 parts.alertMail.none=Disabled
 parts.alertMail.enabled=Enabled
 parts.section.localContents=Local content settings
+parts.localContents.always=Always use
 parts.localContents.enabled=Enabled
 parts.localContents.disabled=Disabled
 parts.localContents.contents=Content

--- a/conf/messages.ja
+++ b/conf/messages.ja
@@ -73,6 +73,7 @@ parts.alertMail.selectOne=どちらか指定必須、両方指定も可能
 parts.alertMail.none=送信しません
 parts.alertMail.enabled=有効
 parts.section.localContents=ローカルコンテンツ設定
+parts.localContents.always=いつも使う
 parts.localContents.enabled=有効
 parts.localContents.disabled=無効
 parts.localContents.contents=コンテンツ

--- a/conf/messages.ja
+++ b/conf/messages.ja
@@ -46,6 +46,7 @@ parts.hystrix.commandGroupKey=グループ
 parts.hystrix.timeoutInMs=タイムアウト
 parts.hystrix.timeoutInMs.label=タイムアウト（ミリ秒）
 parts.hystrix.none.title=エラー！
+parts.hystrix.localContentsAsFallback=エラーのとき、ローカルコンテンツをフォルバックとして使う
 parts.hystrix.none.body=Hystrix設定データがありません。
 parts.section.cache=キャッシュ設定
 parts.cache.ttl=有効期限

--- a/java-client/src/test/scala/com/m3/octoparts/client/ExtractorsSpec.scala
+++ b/java-client/src/test/scala/com/m3/octoparts/client/ExtractorsSpec.scala
@@ -22,7 +22,7 @@ class ExtractorsSpec extends FunSpec with Matchers {
   describe("EndpointListExtractor") {
     it("should extract something that has just been serialized") {
       val configs = Seq(HttpPartConfig("p", "me", "http://localhost", Some(""),
-        HttpMethod.Post, HystrixConfig(5.seconds, ThreadPoolConfig("knitty", 1, 10), "p", "knitty"), alertMailsEnabled = false, alertInterval = 50.minutes))
+        HttpMethod.Post, HystrixConfig(5.seconds, ThreadPoolConfig("knitty", 1, 10), "p", "knitty", false), alertMailsEnabled = false, alertInterval = 50.minutes))
       val serialized = OctopartsApiBuilder.Mapper.writeValueAsBytes(configs)
       EndpointListExtractor.deserialize(new ByteArrayInputStream(serialized)) should equal(SeqWrapper(configs))
     }

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/HystrixConfig.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/HystrixConfig.scala
@@ -8,4 +8,5 @@ import scala.concurrent.duration.FiniteDuration
 case class HystrixConfig(@(ApiModelProperty @field)(required = true, dataType = "integer", value = "in ms") timeout: FiniteDuration,
                          @(ApiModelProperty @field)(required = true) threadPoolConfig: ThreadPoolConfig,
                          @(ApiModelProperty @field)(required = true) commandKey: String,
-                         @(ApiModelProperty @field)(required = true) commandGroupKey: String)
+                         @(ApiModelProperty @field)(required = true) commandGroupKey: String,
+                         @(ApiModelProperty @field)(required = true) localContentsAsFallback: Boolean)

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/OctoClientSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/OctoClientSpec.scala
@@ -77,7 +77,8 @@ class OctoClientSpec extends FunSpec with Matchers with ScalaFutures with Mockit
           coreSize = 2,
           queueSize = 256),
         commandKey = "command",
-        commandGroupKey = "GroupKey"),
+        commandGroupKey = "GroupKey",
+        false),
       additionalValidStatuses = Set(302),
       parameters = Set(
         PartParam(

--- a/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
+++ b/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
@@ -151,7 +151,7 @@ class HttpPartRequestHandlerSpec extends FunSpec with Matchers with ScalaFutures
       def uriToInterpolate = stringToInterpolate
 
       val hystrixExecutor = new HystrixExecutor(null) {
-        override def future[T](f: => T) = Future.successful(f)
+        override def future[T](f: => T, fallbackTransform: Option[String] => T) = Future.successful(f)
       }
 
       def httpMethod = Get

--- a/test/com/m3/octoparts/hystrix/HystrixExecutorSpec.scala
+++ b/test/com/m3/octoparts/hystrix/HystrixExecutorSpec.scala
@@ -10,26 +10,64 @@ import com.m3.octoparts.support.mocks.ConfigDataMocks
 
 class HystrixExecutorSpec extends FunSpec with Matchers with ScalaFutures with ConfigDataMocks {
 
-  lazy val hystrixArguments = mockHystrixConfig.copy(timeoutInMs = 100L)
+  val noFallbackConfig = mockHttpPartConfig.copy(
+    localContents = Some("9"),
+    hystrixConfig = Some(mockHystrixConfig.copy(timeoutInMs = 500L)))
 
-  implicit val p = PatienceConfig(timeout = 2 seconds)
+  val fallbackConfig = mockHttpPartConfig.copy(
+    localContents = Some("9"),
+    hystrixConfig = Some(mockHystrixConfig.copy(localContentsAsFallback = true, timeoutInMs = 500L)))
+
+  implicit val p = PatienceConfig(timeout = 5 seconds)
 
   describe("#future") {
+
     it("should return a Future[Result] that makes sense") {
-      val executor = HystrixExecutor(hystrixArguments)
-      val f = executor.future { 3 }
+      val executor = HystrixExecutor(noFallbackConfig)
+      val f = executor.future(3, _.map(_.toInt).getOrElse(90))
       whenReady(f) { _ should be(3) }
     }
-    it("should time out if blocked beyond the timeout limit") {
-      val executor = HystrixExecutor(hystrixArguments)
-      val f = executor.future {
-        Thread.sleep((3 seconds).toMillis)
+
+    describe("failure handling") {
+
+      it("should time out if blocked beyond the timeout limit") {
+        val executor = HystrixExecutor(noFallbackConfig)
+        val f = executor.future(
+          Thread.sleep((3 seconds).toMillis),
+          _ => ()
+        )
+        whenReady(f.failed) { e =>
+          e shouldBe a[HystrixRuntimeException]
+          e.getCause shouldBe a[TimeoutException]
+        }
       }
-      whenReady(f.failed) { e =>
-        e shouldBe a[HystrixRuntimeException]
-        e.getCause shouldBe a[TimeoutException]
+
+      it("should not time out if blocked beyond the timeout limit and localContentsAsFallback is true") {
+        val executor = HystrixExecutor(fallbackConfig)
+        val f = executor.future(
+          {
+            Thread.sleep((3 seconds).toMillis)
+            9
+          },
+          _.map(_.toInt).getOrElse(90)
+        )
+        whenReady(f) { _ shouldBe 9 }
       }
+
+      it("should not error out if the function throws and localContentsAsFallback is true") {
+        val executor = HystrixExecutor(fallbackConfig)
+        val f = executor.future(
+          {
+            throw new IllegalArgumentException
+            9
+          },
+          _.map(_.toInt).getOrElse(90)
+        )
+        whenReady(f) { _ shouldBe 9 }
+      }
+
     }
+
   }
 
 }

--- a/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
+++ b/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
@@ -35,7 +35,8 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
             coreSize = 2,
             queueSize = 256),
           commandKey = "command",
-          commandGroupKey = "GroupKey"),
+          commandGroupKey = "GroupKey",
+          false),
         additionalValidStatuses = Set(302),
         parameters = Set(
           json.PartParam(

--- a/test/com/m3/octoparts/model/config/JsonConversionSpec.scala
+++ b/test/com/m3/octoparts/model/config/JsonConversionSpec.scala
@@ -45,8 +45,9 @@ class JsonConversionSpec extends FunSpec with Matchers with Checkers with Genera
       threadPoolConfig <- arbThreadPoolConfig.arbitrary
       commandKey <- Arbitrary.arbString.arbitrary
       commandGroupKey <- Arbitrary.arbString.arbitrary
+      localContentsAsFallback <- Arbitrary.arbBool.arbitrary
     } yield {
-      json.HystrixConfig(timeout, threadPoolConfig, commandKey, commandGroupKey)
+      json.HystrixConfig(timeout, threadPoolConfig, commandKey, commandGroupKey, localContentsAsFallback)
     }
   }
 

--- a/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
+++ b/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
@@ -200,6 +200,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
         threadPoolConfigId = Some(ThreadPoolConfigRepository.save(threadPool)),
         commandKey = "myCommand",
         commandGroupKey = "myCommandGroup",
+        localContentsAsFallback = false,
         createdAt = DateTime.now,
         updatedAt = DateTime.now)
 

--- a/test/com/m3/octoparts/support/mocks/ConfigDataMocks.scala
+++ b/test/com/m3/octoparts/support/mocks/ConfigDataMocks.scala
@@ -51,6 +51,7 @@ trait ConfigDataMocks {
     commandGroupKey = "GroupKey",
     timeoutInMs = 50L,
     threadPoolConfig = Some(mockThreadConfig),
+    localContentsAsFallback = false,
     createdAt = now,
     updatedAt = now
   )

--- a/test/controllers/AdminControllerSpec.scala
+++ b/test/controllers/AdminControllerSpec.scala
@@ -120,10 +120,11 @@ class AdminControllerSpec extends FunSpec
     "description" -> "stuff",
     "uri" -> "http://www.example2.com",
     "method" -> "post",
-    "commandKey" -> "commandKey",
-    "commandGroupKey" -> "commandGroupKey",
-    "timeoutInMs" -> "5000",
-    "threadPoolConfigId" -> "3"
+    "hystrixConfig.commandKey" -> "commandKey",
+    "hystrixConfig.commandGroupKey" -> "commandGroupKey",
+    "hystrixConfig.timeoutInMs" -> "5000",
+    "hystrixConfig.threadPoolConfigId" -> "3",
+    "hystrixConfig.localContentsAsFallback" -> "true"
   )
 
   it("should show a list of parts") {

--- a/test/controllers/AdminFormsSpec.scala
+++ b/test/controllers/AdminFormsSpec.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.m3.octoparts.model.config.{ PartParam, CacheGroup }
 import com.m3.octoparts.support.mocks.ConfigDataMocks
-import controllers.AdminForms.{ LocalContentsConfig, PartData }
+import controllers.AdminForms.{ HystrixConfigData, LocalContentsConfig, PartData }
 import org.scalatest.{ FunSpec, Matchers }
 
 class AdminFormsSpec extends FunSpec with Matchers with ConfigDataMocks {
@@ -15,10 +15,13 @@ class AdminFormsSpec extends FunSpec with Matchers with ConfigDataMocks {
       uri = "",
       method = "get",
       additionalValidStatuses = None,
-      commandKey = "",
-      commandGroupKey = "",
-      timeoutInMs = 1000L,
-      threadPoolConfigId = 42L,
+      HystrixConfigData(
+        commandKey = "",
+        commandGroupKey = "",
+        timeoutInMs = 1000L,
+        threadPoolConfigId = 42L,
+        localContentsAsFallback = false
+      ),
       cacheGroupNames = Nil,
       ttl = None,
       alertMailsEnabled = false,


### PR DESCRIPTION
In the case of catastrophic Hystrix failure, use localContents as fallback.

Closes #76 