### PR TITLE
Try to support building the body param for the scala-ws-client

### DIFF
--- a/scala-ws-client/src/main/scala/com/m3/octoparts/ws/PartRequestEnrichment.scala
+++ b/scala-ws-client/src/main/scala/com/m3/octoparts/ws/PartRequestEnrichment.scala
@@ -1,0 +1,29 @@
+package com.m3.octoparts.ws
+
+import java.nio.charset.StandardCharsets
+
+import com.m3.octoparts.model.{ PartRequestParam, PartRequest }
+import play.api.http.Writeable
+
+/**
+ * An enrichment for [[PartRequest]] to offer nice helpers
+ */
+object PartRequestEnrichment {
+
+  private val BodyParamKey: String = "body"
+
+  implicit class RichPartRequest(val partReq: PartRequest) extends AnyVal {
+
+    /**
+     * Given a body type with a [[Writeable]] available, returns a PartRequest with
+     * the properly formatted body param [[PartRequestParam]] (key of body, and only one)
+     */
+    def withBody[A: Writeable](body: A): PartRequest = {
+      val bodyAsString = new String(implicitly[Writeable[A]].transform(body), StandardCharsets.UTF_8)
+      val paramsWithBody = partReq.params.filterNot(_.key == BodyParamKey) :+ PartRequestParam(BodyParamKey, bodyAsString)
+      partReq.copy(params = paramsWithBody)
+    }
+
+  }
+
+}

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartRequestSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartRequestSpec.scala
@@ -1,0 +1,29 @@
+package com.m3.octoparts.ws
+
+import com.m3.octoparts.model.{ PartRequestParam, PartRequest }
+import org.scalatest._
+import play.api.http.Writeable
+
+class RichPartRequestSpec extends FunSpec with Matchers {
+
+  describe("#withBody") {
+
+    import PartRequestEnrichment._
+    implicit val tuple3IntWriteable = new Writeable[(Int, Int, Int)](transform = { a => s"${a._1 + a._2 + a._3}".getBytes }, None)
+
+    it("should add a PartRequestParam with a key of 'body' and a value of whatever the implicit Writeable.transform returns as a string") {
+      val pr = PartRequest("hello")
+      val prWithBody = pr.withBody((1, 2, 3))
+      prWithBody.params.find(_.key == "body").head.value shouldBe ("6")
+    }
+
+    it("should ensure that there is only 1 'body' param in the part request; the one it adds") {
+      val pr = PartRequest("hello", params = Seq(PartRequestParam("body", "booo")))
+      val prWithBody = pr.withBody((9, 10, 11))
+      prWithBody.params.filter(_.key == "body").size shouldBe 1
+      prWithBody.params.find(_.key == "body").head.value shouldBe ("30")
+    }
+
+  }
+
+}

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartRequestSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartRequestSpec.scala
@@ -1,5 +1,7 @@
 package com.m3.octoparts.ws
 
+import java.nio.charset.StandardCharsets
+
 import com.m3.octoparts.model.{ PartRequestParam, PartRequest }
 import org.scalatest._
 import play.api.http.Writeable
@@ -9,7 +11,8 @@ class RichPartRequestSpec extends FunSpec with Matchers {
   describe("#withBody") {
 
     import PartRequestEnrichment._
-    implicit val tuple3IntWriteable = new Writeable[(Int, Int, Int)](transform = { a => s"${a._1 + a._2 + a._3}".getBytes }, None)
+    implicit val tuple3IntWriteable = new Writeable[(Int, Int, Int)](
+      transform = { a => s"${a._1 + a._2 + a._3}".getBytes(StandardCharsets.UTF_8) }, None)
 
     it("should add a PartRequestParam with a key of 'body' and a value of whatever the implicit Writeable.transform returns as a string") {
       val pr = PartRequest("hello")

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/Sample.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/Sample.scala
@@ -8,6 +8,8 @@ import play.api.libs.json.Json
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
+import PartRequestEnrichment._
+
 /**
  * Sample showing how to use the client.
  */
@@ -43,7 +45,19 @@ object Sample {
   val requests = Seq(
     // A list of the endpoints you want to call, with parameters to send
     PartRequest(partId = "UserProfile", params = Seq(PartRequestParam("uid", "123"))),
-    PartRequest(partId = "LatestNews", params = Seq(PartRequestParam("limit", "10")))
+    PartRequest(partId = "LatestNews", params = Seq(PartRequestParam("limit", "10"))),
+
+    // Example of adding a Json string as the "body" parameter for a request
+    PartRequest(partId = "TrackView", params = Seq(PartRequestParam("uid", "123"))).withBody(Json.obj("hello" -> "world")),
+
+    // Example of adding a UrlEncodedForm string as the "body" parameter for a request
+    PartRequest(
+      partId = "TrackClick",
+      params = Seq(
+        PartRequestParam("uid", "123")
+      )
+    ).withBody(Map("tabs" -> Seq("1", "2", "3")))
+
   )
 
   // Send the requests, get back a Future


### PR DESCRIPTION
Related to #100

Seemed reasonable to me that for the scala-ws-client, we might as well take advantage of the `Writeable` typeclass already provided to us. Allows us to support form, json, string, and xml encoding right away.