### PR TITLE
Help create a java.net.URI

### DIFF
--- a/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
+++ b/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
@@ -114,6 +114,12 @@ class HttpPartRequestHandlerSpec extends FunSpec with Matchers with ScalaFutures
       headers should contain("X-OCTOPARTS-REQUEST-ID" -> "bande a part")
       headers should contain("X-OCTOPARTS-PARENT-REQUEST-ID" -> "hey man that's so meta")
     }
+    it("should be able to pass exotic query params") {
+      val hArgs = Map(
+        ShortPartParam("query1", Query) -> Seq("\"'&=")
+      )
+      handler.createBlockingHttpRetrieve(partRequestInfo, hArgs).uri.getQuery shouldBe "query1=\"'&="
+    }
   }
 
   describe("#collectHeaders") {


### PR DESCRIPTION
typical error:

Illegal character in query at index X where the URL contains a double quote
    com.m3.octoparts.aggregator.handler.HttpPartRequestHandler$$anon$1 in <init> at line 73 (application)
    com.m3.octoparts.aggregator.handler.HttpPartRequestHandler$class in createBlockingHttpRetrieve at line 70 (application)
    com.m3.octoparts.aggregator.handler.SimpleHttpPartRequestHandler in createBlockingHttpRetrieve at line 18 (application)
    com.m3.octoparts.aggregator.handler.HttpPartRequestHandler$$anonfun$process$1 in apply at line 57 (application)
    com.m3.octoparts.aggregator.handler.HttpPartRequestHandler$$anonfun$process$1 in apply at line 57 (application)
    com.m3.octoparts.hystrix.HystrixExecutor$$anon$1 in run at line 40 (application)
