### PR TITLE
Make explicit that the Java client builds on Java8

### DIFF
--- a/java-client/README.markdown
+++ b/java-client/README.markdown
@@ -1,6 +1,8 @@
 # Java client
 
-This simple client uses Async HTTP Client for transport. It is built for Java 6 but should work on Java 7 and 8
+This simple client uses Async HTTP Client for transport. It is build for Java 8 but should compile on Java 7 too.
+
+*It will not run on Java 6*
 
 See Sample.java for usage
 

--- a/project/Octoparts.scala
+++ b/project/Octoparts.scala
@@ -47,8 +47,6 @@ object Octoparts extends Build {
   lazy val javaClient = nonPlayProject("java-client")()
     .settings(
       name := "octoparts-java-client",
-      javacOptions in compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint"),
-      javacOptions in doc ++= Seq("-source", "1.6"),
       libraryDependencies ++= Dependencies.javaClientDependncies
     )
     .dependsOn(models)


### PR DESCRIPTION
related: https://github.com/m3dev/octoparts/issues/99

The Java client primarily targets Java 8. Users who want to run in against Java 7 are free to try (or rebuild it)