### PR TITLE
Adjust log level based on expected response time

### DIFF
--- a/app/controllers/system/HealthcheckController.scala
+++ b/app/controllers/system/HealthcheckController.scala
@@ -14,7 +14,7 @@ import play.api.mvc.{ Action, Controller }
 import shade.memcached.MemcachedCodecs
 
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 /**
@@ -65,7 +65,11 @@ class HealthcheckController(configsRepo: ConfigsRepository,
       case NonFatal(e) =>
         LTSVLogger.warn(e, "Health check failed" -> "DB")
         DbStatus(ok = false, message = e.toString)
-    } time { case (status, duration) => LTSVLogger.info("DbStatus" -> status, "Time taken" -> toRelevantUnit(duration)) }
+    } time {
+      case (status, duration) if duration > 1.second => LTSVLogger.warn("DbStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+      case (status, duration) if duration > 100.milliseconds => LTSVLogger.debug("DbStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+      case (status, duration) => LTSVLogger.trace("DbStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+    }
   }
 
   /**
@@ -84,7 +88,11 @@ class HealthcheckController(configsRepo: ConfigsRepository,
       }
     } map {
       bools => MemcachedStatus(bools.forall(identity))
-    } time { case (status, duration) => LTSVLogger.info("MemcachedStatus" -> status, "Time taken" -> toRelevantUnit(duration)) }
+    } time {
+      case (status, duration) if duration > 100.milliseconds => LTSVLogger.warn("MemcachedStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+      case (status, duration) if duration > 10.milliseconds => LTSVLogger.debug("MemcachedStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+      case (status, duration) => LTSVLogger.trace("MemcachedStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+    }
   }
 
   /**
@@ -95,7 +103,14 @@ class HealthcheckController(configsRepo: ConfigsRepository,
     val commandKeysWithOpenCircuitBreakers = hystrixHealthReporter.getCommandKeysWithOpenCircuitBreakers
     val ok = commandKeysWithOpenCircuitBreakers.isEmpty
     val hystrixStatus = HystrixStatus(ok, commandKeysWithOpenCircuitBreakers)
-    LTSVLogger.info("HystrixStatus" -> hystrixStatus, "Time taken" -> toRelevantUnit(Duration(System.nanoTime() - startTime, TimeUnit.NANOSECONDS)))
+    val duration = toRelevantUnit(Duration(System.nanoTime() - startTime, TimeUnit.NANOSECONDS))
+    if (duration > 10.milliseconds) {
+      LTSVLogger.warn("HystrixStatus" -> hystrixStatus, "Time taken" -> duration)
+    } else if (duration > 1.milliseconds) {
+      LTSVLogger.debug("HystrixStatus" -> hystrixStatus, "Time taken" -> duration)
+    } else {
+      LTSVLogger.trace("HystrixStatus" -> hystrixStatus, "Time taken" -> duration)
+    }
     hystrixStatus
   }
 }


### PR DESCRIPTION
Just to reduce the amount of log (as healthcheck will happen often, and most of the time it has nothing to say)