### PR TITLE
Feature/fix serialisability

### DIFF
--- a/app/com/m3/octoparts/http/HttpClientPool.scala
+++ b/app/com/m3/octoparts/http/HttpClientPool.scala
@@ -39,7 +39,7 @@ object HttpClientPool {
       httpPoolSize = part.httpPoolSize,
       httpConnectionTimeout = part.httpConnectionTimeout,
       httpSocketTimeout = part.httpSocketTimeout,
-      httpDefaultEncoding = part.httpDefaultEncoding,
+      httpDefaultEncoding = part.httpDefaultEncoding.underlying,
       httpProxySettings = part.httpProxySettings)
   }
 }

--- a/app/com/m3/octoparts/model/config/Charset.scala
+++ b/app/com/m3/octoparts/model/config/Charset.scala
@@ -1,0 +1,32 @@
+package com.m3.octoparts.model.config
+
+import java.nio.charset.{ Charset => JavaCharset }
+
+object Charset {
+
+  /**
+   * Dumb wrapper around [[JavaCharset]].forName
+   */
+  def forName(name: String): Charset = Charset(JavaCharset.forName(name).name())
+
+}
+
+/**
+ * Serialisable version of Java charset
+ *
+ * The constructor is private so use the companion object's forName method to instantiate one
+ */
+case class Charset private (name: String) {
+
+  /**
+   * The underlying [[JavaCharset]] that actually does real work for you :)
+   *
+   * This cannot be a val, otherwise it will get serialised.
+   */
+  def underlying: JavaCharset = JavaCharset.forName(name)
+
+  /**
+   * Override for ORM
+   */
+  override def toString: String = name
+}

--- a/app/com/m3/octoparts/model/config/HttpPartConfig.scala
+++ b/app/com/m3/octoparts/model/config/HttpPartConfig.scala
@@ -1,7 +1,5 @@
 package com.m3.octoparts.model.config
 
-import java.nio.charset.Charset
-
 import com.m3.octoparts.cache.config.CacheConfig
 import com.m3.octoparts.model.HttpMethod
 import com.m3.octoparts.model.config.json.{ HttpPartConfig => JsonHttpPartConfig, AlertMailSettings }
@@ -87,7 +85,7 @@ object HttpPartConfig {
       httpPoolSize = config.httpPoolSize,
       httpConnectionTimeout = config.httpConnectionTimeout,
       httpSocketTimeout = config.httpSocketTimeout,
-      httpDefaultEncoding = config.httpDefaultEncoding,
+      httpDefaultEncoding = config.httpDefaultEncoding.underlying,
       httpProxy = config.httpProxy,
       parameters = config.parameters.map(PartParam.toJsonModel),
       deprecatedInFavourOf = config.deprecatedInFavourOf,
@@ -115,7 +113,7 @@ object HttpPartConfig {
       httpPoolSize = config.httpPoolSize,
       httpConnectionTimeout = config.httpConnectionTimeout,
       httpSocketTimeout = config.httpSocketTimeout,
-      httpDefaultEncoding = config.httpDefaultEncoding,
+      httpDefaultEncoding = Charset.forName(config.httpDefaultEncoding.name),
       httpProxy = config.httpProxy,
       parameters = config.parameters.map(PartParam.fromJsonModel),
       deprecatedInFavourOf = config.deprecatedInFavourOf,

--- a/app/com/m3/octoparts/repository/config/HttpPartConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HttpPartConfigRepository.scala
@@ -1,7 +1,5 @@
 package com.m3.octoparts.repository.config
 
-import java.nio.charset.Charset
-
 import com.beachape.logging.LTSVLogger
 import com.m3.octoparts.model.HttpMethod
 import com.m3.octoparts.model.config._

--- a/app/controllers/AdminForms.scala
+++ b/app/controllers/AdminForms.scala
@@ -1,7 +1,6 @@
 package controllers
 
-import java.nio.charset.Charset
-
+import java.nio.charset.{ Charset => JavaCharset }
 import com.beachape.logging.LTSVLogger
 import com.m3.octoparts.model.HttpMethod
 import com.m3.octoparts.model.config._
@@ -117,7 +116,7 @@ object AdminForms {
         httpPoolSize = part.httpPoolSize,
         httpConnectionTimeoutInMs = part.httpConnectionTimeout.toMillis.toInt,
         httpSocketTimeoutInMs = part.httpSocketTimeout.toMillis.toInt,
-        httpDefaultEncoding = part.httpDefaultEncoding.name(),
+        httpDefaultEncoding = part.httpDefaultEncoding.name,
         httpProxy = part.httpProxy),
       hystrixConfig = HystrixConfigData(
         commandKey = part.hystrixConfigItem.commandKey,
@@ -162,7 +161,7 @@ object AdminForms {
         "httpPoolSize" -> number(min = 1),
         "httpConnectionTimeoutInMs" -> number(min = 0),
         "httpSocketTimeoutInMs" -> number(min = 0),
-        "httpDefaultEncoding" -> text.verifying(string => Charset.isSupported(string)),
+        "httpDefaultEncoding" -> text.verifying(string => JavaCharset.isSupported(string)),
         "httpProxy" -> optional(text)
       )(HttpConfigData.apply)(HttpConfigData.unapply),
       "hystrixConfig" -> mapping(

--- a/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
+++ b/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 
 import com.m3.octoparts.model.HttpMethod
 import com.m3.octoparts.model.config.json.AlertMailSettings
+import org.apache.commons.lang3.SerializationUtils
 import scala.concurrent.duration._
 import com.m3.octoparts.support.mocks.ConfigDataMocks
 import scala.language.postfixOps
@@ -68,6 +69,21 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
         localContentsEnabled = true,
         localContents = Some("{}"))
       jsonModel should be(expectedModel)
+    }
+
+  }
+
+  describe("Java serdes (for caching)") {
+
+    it("should serialise and deserialise without problems") {
+      val original = mockHttpPartConfig.copy(
+        hystrixConfig = Some(mockHystrixConfig),
+        additionalValidStatuses = Set(302),
+        cacheGroups = Set(mockCacheGroup)
+      )
+      val serialised = SerializationUtils.serialize(original)
+      val deserialised = SerializationUtils.deserialize[HttpPartConfig](serialised)
+      deserialised shouldBe original
     }
 
   }

--- a/test/com/m3/octoparts/model/config/JsonConversionSpec.scala
+++ b/test/com/m3/octoparts/model/config/JsonConversionSpec.scala
@@ -1,6 +1,6 @@
 package com.m3.octoparts.model.config
 
-import java.nio.charset.Charset
+import java.nio.charset.{ Charset => JavaCharset }
 import java.util.concurrent.TimeUnit
 
 import com.m3.octoparts.model.HttpMethod
@@ -98,7 +98,7 @@ class JsonConversionSpec extends FunSpec with Matchers with Checkers with Genera
       httpPoolSize <- Gen.chooseNum(1, Int.MaxValue)
       httpConnectionTimeout <- genShortDuration
       httpSocketTimeout <- genShortDuration
-      httpDefaultEncoding <- Gen.oneOf(JCollectionWrapper(Charset.availableCharsets().values()).toSeq)
+      httpDefaultEncoding <- Gen.oneOf(JCollectionWrapper(JavaCharset.availableCharsets().values()).toSeq)
       parameters <- Gen.containerOf[Set, json.PartParam](arbPartParam.arbitrary)
       deprecatedInFavourOf <- Gen.option(Arbitrary.arbString.arbitrary)
       cacheGroups <- Gen.containerOf[Set, json.CacheGroup](arbCacheGroup.arbitrary)

--- a/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
+++ b/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
@@ -54,7 +54,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
         config.httpPoolSize should be(5)
         config.httpConnectionTimeout should be(1.second)
         config.httpSocketTimeout should be(5.seconds)
-        config.httpDefaultEncoding should be(StandardCharsets.UTF_8)
+        config.httpDefaultEncoding.underlying should be(StandardCharsets.UTF_8)
     }
 
     it("should work when passing Option values") {
@@ -266,7 +266,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
             httpPoolSize = 5,
             httpConnectionTimeout = 1.second,
             httpSocketTimeout = 5.seconds,
-            httpDefaultEncoding = StandardCharsets.US_ASCII,
+            httpDefaultEncoding = Charset.forName(StandardCharsets.US_ASCII.name),
             parameters = parameters.toSet,
             hystrixConfig = Some(insertedHystrixConfig),
             cacheTtl = Some(30.seconds),
@@ -301,7 +301,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
           httpPoolSize = 5,
           httpConnectionTimeout = 1.second,
           httpSocketTimeout = 5.seconds,
-          httpDefaultEncoding = StandardCharsets.US_ASCII,
+          httpDefaultEncoding = Charset.forName(StandardCharsets.US_ASCII.name),
           parameters = parameters.toSet,
           hystrixConfig = Some(insertedHystrixConfig),
           cacheTtl = Some(10.minutes),

--- a/test/com/m3/octoparts/support/mocks/ConfigDataMocks.scala
+++ b/test/com/m3/octoparts/support/mocks/ConfigDataMocks.scala
@@ -36,7 +36,7 @@ trait ConfigDataMocks {
     httpPoolSize = 5,
     httpConnectionTimeout = 1.second,
     httpSocketTimeout = 5.seconds,
-    httpDefaultEncoding = StandardCharsets.US_ASCII,
+    httpDefaultEncoding = Charset.forName(StandardCharsets.US_ASCII.name),
     httpProxy = Some("localhost:666"),
     parameters = Set(mockPartParam),
     cacheTtl = Some(60.seconds),


### PR DESCRIPTION
Because we are using Shade's GenericCodec in such a deep place, it's very hard for us now to fix our Charset serialisation/deserialisation errors without doing something like this.

Eventually we should probably refactor our code to make it possible for us to pass a custom codec to the cache layer (which is likely more efficient), but that's a fairly big task.