### PR TITLE
Bump to zipkin-futures version that doesn't double verify spans

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
   val scalaUri            = "com.netaporter"            %% "scala-uri"                    % "0.4.6"
   val findbugs            = "com.google.code.findbugs"  % "jsr305"                        % "3.0.0"
 
-  val zipkinFutures       = "com.beachape"              %% "zipkin-futures-play"          % "0.0.9"
+  val zipkinFutures       = "com.beachape"              %% "zipkin-futures-play"          % "0.1.0"
 
   val withoutExcluded = { (m: ModuleID) =>
     m.excludeAll(


### PR DESCRIPTION
Bump `zipkin-futures` to a version that doesn't verify spans against filters when sending (double verifying because they are already verified on creation).

Due to sampling, this double verification was preventing server spans from being sent (`serverSent`) if the random rate check failed on send but passed on create. This leads to client spans with `Unknown` parent spans in Zipkin.

[Relevant change](https://github.com/lloydmeta/zipkin-futures/commit/e6830d868c7eed5be7ceb1a2525f24f0b49aafcc)