### PR TITLE
Put unique parts in annotations instead of Span names

### DIFF
--- a/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
@@ -58,7 +58,7 @@ trait HttpPartRequestHandler extends Handler {
    * @return Future[PartResponse]
    */
   def process(partRequestInfo: PartRequestInfo, hArgs: HandlerArguments)(implicit parentSpan: Span): Future[PartResponse] = {
-    TracedFuture(s"Http request", "partId" -> partRequestInfo.partRequest.partId) { maybeSpan =>
+    TracedFuture("Http request", "partId" -> partRequestInfo.partRequest.partId) { maybeSpan =>
       hystrixExecutor.future(
         createBlockingHttpRetrieve(partRequestInfo, hArgs, maybeSpan).retrieve(),
         maybeContents => HttpResponse(

--- a/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
@@ -58,7 +58,7 @@ trait HttpPartRequestHandler extends Handler {
    * @return Future[PartResponse]
    */
   def process(partRequestInfo: PartRequestInfo, hArgs: HandlerArguments)(implicit parentSpan: Span): Future[PartResponse] = {
-    TracedFuture(s"Http request for - ${partRequestInfo.partRequest.partId}") { maybeSpan =>
+    TracedFuture(s"Http request", "partId" -> partRequestInfo.partRequest.partId) { maybeSpan =>
       hystrixExecutor.future(
         createBlockingHttpRetrieve(partRequestInfo, hArgs, maybeSpan).retrieve(),
         maybeContents => HttpResponse(

--- a/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
+++ b/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
@@ -1,13 +1,11 @@
 package com.m3.octoparts.cache
 
 import com.beachape.logging.LTSVLogger
-import com.beachape.zipkin.TracedFuture
 import com.m3.octoparts.aggregator.PartRequestInfo
 import com.m3.octoparts.aggregator.service.PartRequestServiceBase
 import com.m3.octoparts.cache.directive.{ CacheDirective, CacheDirectiveGenerator }
 import com.m3.octoparts.model.PartResponse
 import com.m3.octoparts.model.config._
-import com.netflix.hystrix.exception.HystrixRuntimeException
 import com.twitter.zipkin.gen.Span
 import org.apache.http.HttpStatus
 import com.m3.octoparts.cache.RichCacheControl._
@@ -49,7 +47,7 @@ trait PartResponseCachingSupport extends PartRequestServiceBase {
       val futureMaybeFromCache =
         cacheOps.putIfAbsent(directive)(super.processWithConfig(ci, partRequestInfo, params))
           .recoverWith(onCacheFailure(ci, partRequestInfo, params))
-          .trace(s"retrieve-part-response-from-cache-or-else", "partId" -> ci.partId)
+          .trace("retrieve-part-response-from-cache-or-else", "partId" -> ci.partId)
       futureMaybeFromCache.flatMap {
         partResponse =>
           // at this point, the response may come from cache and be stale.

--- a/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
+++ b/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
@@ -7,6 +7,7 @@ import com.m3.octoparts.aggregator.service.PartRequestServiceBase
 import com.m3.octoparts.cache.directive.{ CacheDirective, CacheDirectiveGenerator }
 import com.m3.octoparts.model.PartResponse
 import com.m3.octoparts.model.config._
+import com.netflix.hystrix.exception.HystrixRuntimeException
 import com.twitter.zipkin.gen.Span
 import org.apache.http.HttpStatus
 import com.m3.octoparts.cache.RichCacheControl._
@@ -48,7 +49,7 @@ trait PartResponseCachingSupport extends PartRequestServiceBase {
       val futureMaybeFromCache =
         cacheOps.putIfAbsent(directive)(super.processWithConfig(ci, partRequestInfo, params))
           .recoverWith(onCacheFailure(ci, partRequestInfo, params))
-          .trace(s"retrieve-part-response-from-cache-or-else-${ci.partId}")
+          .trace(s"retrieve-part-response-from-cache-or-else", "partId" -> ci.partId)
       futureMaybeFromCache.flatMap {
         partResponse =>
           // at this point, the response may come from cache and be stale.

--- a/app/com/m3/octoparts/cache/memcached/MemcachedCache.scala
+++ b/app/com/m3/octoparts/cache/memcached/MemcachedCache.scala
@@ -39,7 +39,7 @@ class MemcachedCache(underlying: RawCache, keyGen: MemcachedKeyGenerator)(implic
     try {
       underlying.get[T](serializeKey(key)).recoverWith {
         case NonFatal(err) => throw new CacheException(key, err)
-      }.trace(s"memcached-get", "key" -> StringUtils.abbreviate(key.toString, 150))
+      }.trace("memcached-get", "key" -> StringUtils.abbreviate(key.toString, 150))
     } catch {
       case NonFatal(e) => Future.failed(e)
     }
@@ -59,7 +59,7 @@ class MemcachedCache(underlying: RawCache, keyGen: MemcachedKeyGenerator)(implic
         case _ =>
           underlying.set[T](serializeKey(key), v, ttl.getOrElse(VERY_LONG_TTL)).recoverWith {
             case NonFatal(err) => throw new CacheException(key, err)
-          }.trace(s"memcached-set", "key" -> StringUtils.abbreviate(key.toString, 150), "value" -> StringUtils.abbreviate(v.toString, 150))
+          }.trace("memcached-set", "key" -> StringUtils.abbreviate(key.toString, 150), "value" -> StringUtils.abbreviate(v.toString, 150))
       }
     } catch {
       case NonFatal(e) => Future.failed(e)

--- a/app/com/m3/octoparts/cache/memcached/MemcachedCache.scala
+++ b/app/com/m3/octoparts/cache/memcached/MemcachedCache.scala
@@ -5,6 +5,7 @@ import com.m3.octoparts.cache.{ Cache, CacheException, RawCache }
 import com.m3.octoparts.cache.key._
 import com.beachape.logging.LTSVLogger
 import com.twitter.zipkin.gen.Span
+import org.apache.commons.lang3.StringUtils
 import shade.memcached.Codec
 
 import scala.concurrent.duration._
@@ -38,7 +39,7 @@ class MemcachedCache(underlying: RawCache, keyGen: MemcachedKeyGenerator)(implic
     try {
       underlying.get[T](serializeKey(key)).recoverWith {
         case NonFatal(err) => throw new CacheException(key, err)
-      }.trace(s"memcached-get-$key")
+      }.trace(s"memcached-get", "key" -> StringUtils.abbreviate(key.toString, 150))
     } catch {
       case NonFatal(e) => Future.failed(e)
     }
@@ -58,7 +59,7 @@ class MemcachedCache(underlying: RawCache, keyGen: MemcachedKeyGenerator)(implic
         case _ =>
           underlying.set[T](serializeKey(key), v, ttl.getOrElse(VERY_LONG_TTL)).recoverWith {
             case NonFatal(err) => throw new CacheException(key, err)
-          }.trace(s"memcached-set-$key")
+          }.trace(s"memcached-set", "key" -> StringUtils.abbreviate(key.toString, 150), "value" -> StringUtils.abbreviate(v.toString, 150))
       }
     } catch {
       case NonFatal(e) => Future.failed(e)

--- a/app/com/m3/octoparts/repository/DBConfigsRepository.scala
+++ b/app/com/m3/octoparts/repository/DBConfigsRepository.scala
@@ -150,7 +150,7 @@ trait MutableDBRepository extends MutableConfigsRepository {
   private val zipkinSpanNameBase = "db-repo-mutation"
 
   def save[A <: ConfigModel[A]: ConfigMapper](obj: A)(implicit parentSpan: Span): Future[Long] = {
-    DB.futureLocalTx { implicit session => saveWithSession(implicitly[ConfigMapper[A]], obj) }.trace(s"$zipkinSpanNameBase-save:$obj")
+    DB.futureLocalTx { implicit session => saveWithSession(implicitly[ConfigMapper[A]], obj) }.trace(s"$zipkinSpanNameBase-save", "object" -> obj.toString)
   }
 
   def deleteAllConfigs()(implicit parentSpan: Span): Future[Int] = {

--- a/app/com/m3/octoparts/repository/DBConfigsRepository.scala
+++ b/app/com/m3/octoparts/repository/DBConfigsRepository.scala
@@ -57,7 +57,7 @@ trait ImmutableDBRepository extends ConfigsRepository {
   // Configs
   def findConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Option[HttpPartConfig]] = {
     getWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId), includes = Seq(HttpPartConfigRepository.hystrixConfigRef))
-      .trace(s"$zipkinSpanNameBase-findConfigByPartId:$partId")
+      .trace(s"$zipkinSpanNameBase-findConfigByPartId", "partId" -> partId)
   }
 
   def findAllConfigs()(implicit parentSpan: Span): Future[Seq[HttpPartConfig]] = {
@@ -67,13 +67,13 @@ trait ImmutableDBRepository extends ConfigsRepository {
 
   def findParamById(id: Long)(implicit parentSpan: Span): Future[Option[PartParam]] = {
     getWithSession(PartParamRepository, sqls.eq(PartParamRepository.defaultAlias.id, id), joins = Seq(PartParamRepository.httpPartConfigRef))
-      .trace(s"$zipkinSpanNameBase-findParamById:$id")
+      .trace(s"$zipkinSpanNameBase-findParamById", "id" -> id.toString)
   }
 
   // For ThreadPoolConfigs
   def findThreadPoolConfigById(id: Long)(implicit parentSpan: Span): Future[Option[ThreadPoolConfig]] = {
     getWithSession(ThreadPoolConfigRepository, sqls.eq(ThreadPoolConfigRepository.defaultAlias.id, id))
-      .trace(s"$zipkinSpanNameBase-findThreadPoolConfigById:$id")
+      .trace(s"$zipkinSpanNameBase-findThreadPoolConfigById", "id" -> id.toString)
   }
 
   def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[Seq[ThreadPoolConfig]] = {
@@ -84,14 +84,14 @@ trait ImmutableDBRepository extends ConfigsRepository {
   // For CacheGroups
   def findCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Option[CacheGroup]] = {
     getWithSession(CacheGroupRepository, sqls.eq(CacheGroupRepository.defaultAlias.name, name), joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
-      .trace(s"$zipkinSpanNameBase-findCacheGroupByName:$name")
+      .trace(s"$zipkinSpanNameBase-findCacheGroupByName", "name" -> name)
   }
 
   def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span): Future[Seq[CacheGroup]] = if (names.isEmpty) {
     Future.successful(Nil)
   } else {
     getAllByWithSession(CacheGroupRepository, sqls.in(CacheGroupRepository.defaultAlias.name, names), joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
-      .trace(s"$zipkinSpanNameBase-findAllCacheGroupsByName:$names")
+      .trace(s"$zipkinSpanNameBase-findAllCacheGroupsByName", "names" -> names.toString)
   }
 
   def findAllCacheGroups()(implicit parentSpan: Span): Future[Seq[CacheGroup]] = {
@@ -159,22 +159,22 @@ trait MutableDBRepository extends MutableConfigsRepository {
 
   def deleteConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Int] = {
     deleteWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId))
-      .trace(s"$zipkinSpanNameBase-deleteConfigByPartId:$partId")
+      .trace(s"$zipkinSpanNameBase-deleteConfigByPartId", "partId" -> partId)
   }
 
   def deletePartParamById(id: Long)(implicit parentSpan: Span) = {
     deleteWithSession(PartParamRepository, sqls.eq(PartParamRepository.defaultAlias.id, id))
-      .trace(s"$zipkinSpanNameBase-deletePartParamById:$id")
+      .trace(s"$zipkinSpanNameBase-deletePartParamById", "id" -> id.toString)
   }
 
   def deleteThreadPoolConfigById(id: Long)(implicit parentSpan: Span) = {
     deleteWithSession(ThreadPoolConfigRepository, sqls.eq(ThreadPoolConfigRepository.defaultAlias.id, id))
-      .trace(s"$zipkinSpanNameBase-deleteThreadPoolConfigById:$id")
+      .trace(s"$zipkinSpanNameBase-deleteThreadPoolConfigById", "id" -> id.toString)
   }
 
   def deleteCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Int] = {
     deleteWithSession(CacheGroupRepository, sqls.eq(CacheGroupRepository.defaultAlias.name, name))
-      .trace(s"$zipkinSpanNameBase-deleteCacheGroupByName:$name")
+      .trace(s"$zipkinSpanNameBase-deleteCacheGroupByName", "name" -> name)
   }
 
   /**

--- a/app/controllers/PartsController.scala
+++ b/app/controllers/PartsController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import javax.ws.rs.QueryParam
 
-import com.beachape.zipkin.{ TracedFuture, ReqHeaderToSpanImplicit }
+import com.beachape.zipkin.ReqHeaderToSpanImplicit
 import com.beachape.zipkin.services.ZipkinServiceLike
 import com.m3.octoparts.json.format.ConfigModel._
 import com.m3.octoparts.json.format.ReqResp._
@@ -77,7 +77,7 @@ class PartsController(
     val fConfigs = partIdParams match {
       case Nil => configsRepository.findAllConfigs().trace("find-all-configs")
       case partIds =>
-        val fParts = partIds.map(id => configsRepository.findConfigByPartId(id).trace(s"find-config-by-part-ids", "ids" -> id.toString))
+        val fParts = partIds.map(id => configsRepository.findConfigByPartId(id).trace("find-config-by-part-ids", "ids" -> id.toString))
         Future.sequence(fParts).map(_.flatten)
     }
 

--- a/app/controllers/PartsController.scala
+++ b/app/controllers/PartsController.scala
@@ -77,7 +77,7 @@ class PartsController(
     val fConfigs = partIdParams match {
       case Nil => configsRepository.findAllConfigs().trace("find-all-configs")
       case partIds =>
-        val fParts = partIds.map(id => configsRepository.findConfigByPartId(id).trace(s"find-config-by-part-ids: ${id}"))
+        val fParts = partIds.map(id => configsRepository.findConfigByPartId(id).trace(s"find-config-by-part-ids", "ids" -> id.toString))
         Future.sequence(fParts).map(_.flatten)
     }
 


### PR DESCRIPTION
Zipkin UI tries to get all Span names for a service when rendering the dropdown. This was causing our Cassandra nodes to fall over because we have too many unique Span names.