### PR TITLE
Feature/lists sorted

### DIFF
--- a/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
@@ -33,7 +33,7 @@ trait HttpPartRequestHandler extends Handler {
 
   def httpMethod: HttpMethod.Value
 
-  def additionalValidStatuses: Set[Int]
+  protected def additionalValidStatuses: Int => Boolean
 
   def hystrixExecutor: HystrixExecutor
 
@@ -41,8 +41,6 @@ trait HttpPartRequestHandler extends Handler {
    * A regex for matching "${...}" placeholders in strings
    */
   private val PlaceholderReplacer: Regex = """\$\{([^\}]+)\}""".r
-
-  // def registeredParams: Set[PartParam]
 
   /**
    * Given arguments for this handler, builds a blocking HTTP request with the proper
@@ -121,7 +119,7 @@ trait HttpPartRequestHandler extends Handler {
     cacheControl = httpResp.cacheControl,
     contents = httpResp.body,
     retrievedFromLocalContents = httpResp.fromFallback,
-    errors = if (httpResp.status < 400 || additionalValidStatuses.contains(httpResp.status)) Nil else Seq(httpResp.message)
+    errors = if (httpResp.status < 400 || additionalValidStatuses(httpResp.status)) Nil else Seq(httpResp.message)
   )
 
   /**

--- a/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
+++ b/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
@@ -20,7 +20,6 @@ class SimpleHttpHandlerFactory(httpClientPool: HttpClientPool, implicit val zipk
       uriToInterpolate = config.uriToInterpolate,
       httpMethod = config.method,
       additionalValidStatuses = config.additionalValidStatuses,
-      registeredParams = config.parameters,
       hystrixExecutor = HystrixExecutor(config)
     )
   }

--- a/app/com/m3/octoparts/aggregator/handler/SimpleHttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/SimpleHttpPartRequestHandler.scala
@@ -4,8 +4,8 @@ import com.beachape.zipkin.services.ZipkinServiceLike
 import com.m3.octoparts.http._
 import com.m3.octoparts.hystrix._
 import com.m3.octoparts.model.HttpMethod
-import com.m3.octoparts.model.config._
 
+import scala.collection.SortedSet
 import scala.concurrent.ExecutionContext
 
 /**
@@ -13,15 +13,13 @@ import scala.concurrent.ExecutionContext
  *
  * @param uriToInterpolate String
  * @param httpMethod HttpMethod
- * @param registeredParams a Seq[Param] describing the r
  * @param hystrixExecutor HystrixExecutor
  */
 class SimpleHttpPartRequestHandler(
   val partId: String,
   val httpClient: HttpClientLike,
   val uriToInterpolate: String,
-  val httpMethod: HttpMethod.Value = HttpMethod.Get,
-  val additionalValidStatuses: Set[Int] = Set.empty,
-  val registeredParams: Set[PartParam] = Set.empty,
+  val httpMethod: HttpMethod.Value,
+  val additionalValidStatuses: SortedSet[Int],
   val hystrixExecutor: HystrixExecutor)(implicit val executionContext: ExecutionContext, implicit val zipkinService: ZipkinServiceLike)
     extends HttpPartRequestHandler

--- a/app/com/m3/octoparts/aggregator/service/RequestParamSupport.scala
+++ b/app/com/m3/octoparts/aggregator/service/RequestParamSupport.scala
@@ -4,6 +4,8 @@ import com.m3.octoparts.aggregator.PartRequestInfo
 import com.m3.octoparts.model.config._
 import com.m3.octoparts.model.{ PartRequestParam, RequestMeta }
 
+import scala.collection.SortedSet
+
 /**
  * Trait to support generic operations on PartRequestInfo components like
  * RequestMeta and PartRequest
@@ -21,7 +23,7 @@ trait RequestParamSupport {
    *
    * @param partRequestInfo Part request info
    */
-  def combineParams(registeredParams: Set[PartParam], partRequestInfo: PartRequestInfo): Map[ShortPartParam, Seq[String]] = {
+  def combineParams(registeredParams: SortedSet[PartParam], partRequestInfo: PartRequestInfo): Map[ShortPartParam, Seq[String]] = {
     val combinedParams = {
       val allParams = processMeta(partRequestInfo.requestMeta) ++ partRequestInfo.partRequest.params
       allParams.groupBy(_.key).mapValues(_.map(_.value))
@@ -35,7 +37,7 @@ trait RequestParamSupport {
     }
 
     // will throw an IllegalArgumentException if a required parameter is missing.
-    validateParams(registeredParams, mappedParams.map(_._1).toSet)
+    validateParams(registeredParams.toSet, mappedParams.map(_._1).toSet)
 
     (for {
       (partParam, values) <- mappedParams

--- a/app/com/m3/octoparts/cache/config/CacheConfig.scala
+++ b/app/com/m3/octoparts/cache/config/CacheConfig.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
  * in order to create a cache directive for the part request.
  */
 case class CacheConfig(ttl: Option[Duration] = None,
-                       versionedParams: Seq[String] = Seq.empty) {
+                       versionedParams: Seq[String] = Nil) {
   // caching is enabled if the TTL is not <= 0
   def cachingEnabled: Boolean = ttl.fold(true)(_.toSeconds > 0)
 }

--- a/app/com/m3/octoparts/http/HttpResponse.scala
+++ b/app/com/m3/octoparts/http/HttpResponse.scala
@@ -22,8 +22,8 @@ import com.m3.octoparts.model.{ CacheControl, Cookie }
 case class HttpResponse(
   status: Int,
   message: String,
-  headers: Seq[(String, String)] = Seq.empty,
-  cookies: Seq[Cookie] = Seq.empty,
+  headers: Seq[(String, String)] = Nil,
+  cookies: Seq[Cookie] = Nil,
   mimeType: Option[String] = None,
   charset: Option[String] = None,
   cacheControl: CacheControl = CacheControl.NotSet,

--- a/app/com/m3/octoparts/http/HttpResponseHandler.scala
+++ b/app/com/m3/octoparts/http/HttpResponseHandler.scala
@@ -15,7 +15,7 @@ import scala.collection.convert.Wrappers.JListWrapper
 import scala.util.Try
 
 /**
- * Custom HttpResponseHandler that returns a [[com.m3.octoparts.http.HttpResponse]] case class
+ * Custom HttpResponseHandler that returns a [[HttpResponse]] case class
  */
 class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[HttpResponse] {
   /**
@@ -23,10 +23,7 @@ class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[Http
    * HttpResponse case class
    *
    * Looks like a big method, but mostly it's mostly just pulling values out of
-   * ApacheHttpResponse
-   *
-   * @param apacheResp [[org.apache.http.HttpResponse]]
-   * @return HttpResponse
+   * [[ApacheHttpResponse]]
    */
   def handleResponse(apacheResp: ApacheHttpResponse): HttpResponse = {
     val headers = apacheResp.getAllHeaders.toSeq
@@ -56,7 +53,7 @@ class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[Http
     Try {
       // HttpCookie.parse may throw an IllegalArgumentException
       JListWrapper(HttpCookie.parse(value))
-    }.getOrElse(Seq.empty)
+    }.getOrElse(Nil)
   }
 
   /**

--- a/app/com/m3/octoparts/hystrix/HystrixHealthReporter.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixHealthReporter.scala
@@ -16,7 +16,7 @@ object HystrixHealthReporter extends HystrixHealthReporter with HystrixCommandMe
    * Get a list of all command keys whose circuit breakers are currently open
    * (i.e. the command is unhealthy)
    */
-  override def getCommandKeysWithOpenCircuitBreakers: Seq[String] = {
+  def getCommandKeysWithOpenCircuitBreakers: Seq[String] = {
     (for {
       m <- getAllMetrics
       ck = m.getCommandKey

--- a/app/com/m3/octoparts/model/config/CacheGroup.scala
+++ b/app/com/m3/octoparts/model/config/CacheGroup.scala
@@ -2,6 +2,9 @@ package com.m3.octoparts.model.config
 
 import org.joda.time.DateTime
 import com.m3.octoparts.model.config.json.{ CacheGroup => JsonCacheGroup }
+
+import scala.collection.SortedSet
+
 /**
  * Defines a group of objects that need to have their cache invalidated as a group
  */
@@ -10,8 +13,8 @@ case class CacheGroup(
   name: String,
   owner: String,
   description: String = "",
-  httpPartConfigs: Seq[HttpPartConfig] = Seq.empty,
-  partParams: Seq[PartParam] = Seq.empty,
+  httpPartConfigs: SortedSet[HttpPartConfig] = SortedSet.empty,
+  partParams: SortedSet[PartParam] = SortedSet.empty,
   createdAt: DateTime,
   updatedAt: DateTime) extends ConfigModel[CacheGroup]
 
@@ -34,4 +37,6 @@ object CacheGroup {
       updatedAt = DateTime.now
     )
   }
+
+  implicit val order: Ordering[CacheGroup] = Ordering.by(_.name)
 }

--- a/app/com/m3/octoparts/model/config/HttpPartConfig.scala
+++ b/app/com/m3/octoparts/model/config/HttpPartConfig.scala
@@ -3,8 +3,10 @@ package com.m3.octoparts.model.config
 import com.m3.octoparts.cache.config.CacheConfig
 import com.m3.octoparts.model.HttpMethod
 import com.m3.octoparts.model.config.json.{ HttpPartConfig => JsonHttpPartConfig, AlertMailSettings }
+import org.apache.http.HttpStatus
 import org.joda.time.DateTime
 
+import scala.collection.SortedSet
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Try
@@ -22,16 +24,16 @@ case class HttpPartConfig(id: Option[Long] = None, // None means that the record
                           description: Option[String],
                           uriToInterpolate: String,
                           method: HttpMethod.Value,
-                          additionalValidStatuses: Set[Int] = Set.empty,
+                          additionalValidStatuses: SortedSet[Int] = SortedSet.empty,
                           httpPoolSize: Int,
                           httpConnectionTimeout: FiniteDuration,
                           httpSocketTimeout: FiniteDuration,
                           httpDefaultEncoding: Charset,
                           httpProxy: Option[String] = None,
-                          parameters: Set[PartParam] = Set.empty,
+                          parameters: SortedSet[PartParam] = SortedSet.empty,
                           hystrixConfig: Option[HystrixConfig] = None,
                           deprecatedInFavourOf: Option[String] = None,
-                          cacheGroups: Set[CacheGroup] = Set.empty,
+                          cacheGroups: SortedSet[CacheGroup] = SortedSet.empty,
                           cacheTtl: Option[FiniteDuration] = Some(Duration.Zero), // in seconds
                           alertMailsEnabled: Boolean,
                           alertAbsoluteThreshold: Option[Int],
@@ -51,7 +53,7 @@ case class HttpPartConfig(id: Option[Long] = None, // None means that the record
 
   def cacheConfig: CacheConfig = {
     // make sure the order of parameters never changes (using DB id)
-    val versionedParamNames = parameters.filter(_.versioned).toSeq.sortBy(_.id).map(_.outputName)
+    val versionedParamNames = parameters.toSeq.filter(_.versioned).sortBy(_.id).map(_.outputName)
     CacheConfig(cacheTtl, versionedParamNames)
   }
 
@@ -61,12 +63,23 @@ case class HttpPartConfig(id: Option[Long] = None, // None means that the record
 
 object HttpPartConfig {
 
-  def parseValidStatuses(mbVal: Option[String]): Set[Int] = mbVal.fold(Set.empty[Int]) {
-    _.split(",").flatMap { tok =>
-      Try {
+  /**
+   * Parses a CSV string, and filters out tokens that are not numbers >= 400.
+   * @return a sorted list of unique statuses.
+   */
+  def parseValidStatuses(mbVal: Option[String]): SortedSet[Int] = {
+    val validStatuses = for {
+      someVal <- mbVal.toSeq
+      if someVal.nonEmpty
+      tok <- someVal.split(',')
+      status <- Try {
         tok.trim.toInt
       }.toOption
-    }.toSet
+      if status >= HttpStatus.SC_BAD_REQUEST
+    } yield {
+      status
+    }
+    validStatuses.to[SortedSet]
   }
 
   /**
@@ -81,15 +94,15 @@ object HttpPartConfig {
       uriToInterpolate = config.uriToInterpolate,
       method = config.method,
       hystrixConfig = HystrixConfig.toJsonModel(config.hystrixConfig.get),
-      additionalValidStatuses = config.additionalValidStatuses,
+      additionalValidStatuses = config.additionalValidStatuses.toSet,
       httpPoolSize = config.httpPoolSize,
       httpConnectionTimeout = config.httpConnectionTimeout,
       httpSocketTimeout = config.httpSocketTimeout,
       httpDefaultEncoding = config.httpDefaultEncoding.underlying,
       httpProxy = config.httpProxy,
-      parameters = config.parameters.map(PartParam.toJsonModel),
+      parameters = config.parameters.toSet.map(PartParam.toJsonModel),
       deprecatedInFavourOf = config.deprecatedInFavourOf,
-      cacheGroups = config.cacheGroups.map(CacheGroup.toJsonModel),
+      cacheGroups = config.cacheGroups.toSet.map(CacheGroup.toJsonModel),
       cacheTtl = config.cacheTtl,
       alertMailSettings = AlertMailSettings(alertMailsEnabled = config.alertMailsEnabled,
         alertAbsoluteThreshold = config.alertAbsoluteThreshold,
@@ -109,15 +122,15 @@ object HttpPartConfig {
       uriToInterpolate = config.uriToInterpolate,
       method = config.method,
       hystrixConfig = Some(HystrixConfig.fromJsonModel(config.hystrixConfig)),
-      additionalValidStatuses = config.additionalValidStatuses,
+      additionalValidStatuses = config.additionalValidStatuses.to[SortedSet],
       httpPoolSize = config.httpPoolSize,
       httpConnectionTimeout = config.httpConnectionTimeout,
       httpSocketTimeout = config.httpSocketTimeout,
       httpDefaultEncoding = Charset.forName(config.httpDefaultEncoding.name),
       httpProxy = config.httpProxy,
-      parameters = config.parameters.map(PartParam.fromJsonModel),
+      parameters = config.parameters.map(PartParam.fromJsonModel).to[SortedSet],
       deprecatedInFavourOf = config.deprecatedInFavourOf,
-      cacheGroups = config.cacheGroups.map(CacheGroup.fromJsonModel),
+      cacheGroups = config.cacheGroups.map(CacheGroup.fromJsonModel).to[SortedSet],
       cacheTtl = config.cacheTtl,
       alertMailsEnabled = config.alertMailSettings.alertMailsEnabled,
       alertAbsoluteThreshold = config.alertMailSettings.alertAbsoluteThreshold,
@@ -131,4 +144,5 @@ object HttpPartConfig {
     )
   }
 
+  implicit val order: Ordering[HttpPartConfig] = Ordering.by(_.partId)
 }

--- a/app/com/m3/octoparts/model/config/HystrixConfig.scala
+++ b/app/com/m3/octoparts/model/config/HystrixConfig.scala
@@ -8,6 +8,7 @@ import scala.language.postfixOps
 
 object HystrixConfig {
   val defaultTimeout = 5.seconds
+  implicit val order: Ordering[HystrixConfig] = Ordering.by(_.commandKey)
 
   /**
    * Returns a [[JsonHystrixConfig]] for a given [[HystrixConfig]]

--- a/app/com/m3/octoparts/model/config/PartParam.scala
+++ b/app/com/m3/octoparts/model/config/PartParam.scala
@@ -3,6 +3,8 @@ package com.m3.octoparts.model.config
 import org.joda.time.DateTime
 import com.m3.octoparts.model.config.json.{ PartParam => JsonPartParam }
 
+import scala.collection.SortedSet
+
 /**
  * Model for holding Parameter configuration data for a Http dependency that
  * comes with a companion-object that can populate it from the database
@@ -24,7 +26,7 @@ case class PartParam(
     paramType: ParamType.Value,
     outputName: String,
     inputNameOverride: Option[String] = None,
-    cacheGroups: Set[CacheGroup] = Set.empty,
+    cacheGroups: SortedSet[CacheGroup] = SortedSet.empty,
     createdAt: DateTime,
     updatedAt: DateTime) extends ConfigModel[PartParam] {
 
@@ -47,7 +49,7 @@ object PartParam {
       outputName = param.outputName,
       inputNameOverride = param.inputNameOverride,
       description = param.description,
-      cacheGroups = param.cacheGroups.map(CacheGroup.toJsonModel)
+      cacheGroups = param.cacheGroups.toSet.map(CacheGroup.toJsonModel)
     )
   }
 
@@ -59,9 +61,11 @@ object PartParam {
       outputName = param.outputName,
       inputNameOverride = param.inputNameOverride,
       description = param.description,
-      cacheGroups = param.cacheGroups.map(CacheGroup.fromJsonModel),
+      cacheGroups = param.cacheGroups.map(CacheGroup.fromJsonModel).to[SortedSet],
       createdAt = DateTime.now,
       updatedAt = DateTime.now
     )
   }
+
+  implicit val order: Ordering[PartParam] = Ordering.by(pp => (pp.outputName, pp.paramType))
 }

--- a/app/com/m3/octoparts/model/config/ThreadPoolConfig.scala
+++ b/app/com/m3/octoparts/model/config/ThreadPoolConfig.scala
@@ -3,6 +3,8 @@ package com.m3.octoparts.model.config
 import org.joda.time.DateTime
 import com.m3.octoparts.model.config.json.{ ThreadPoolConfig => JsonThreadPoolConfig }
 
+import scala.collection.SortedSet
+
 /**
  * Holds ThreadPool Configuration data. Mostly used for Hystrix
  */
@@ -10,12 +12,17 @@ case class ThreadPoolConfig(
     id: Option[Long] = None, // None -> new
     threadPoolKey: String,
     coreSize: Int = ThreadPoolConfig.defaultCoreSize,
-    hystrixConfigs: Seq[HystrixConfig] = Seq.empty,
+    hystrixConfigs: Set[HystrixConfig] = Set.empty,
     createdAt: DateTime,
     updatedAt: DateTime) extends ConfigModel[ThreadPoolConfig] {
 
   // this setting is not yet available for users
   def queueSize: Int = ThreadPoolConfig.defaultQueueSize
+
+  /**
+   * @return a sorted list of related [[HttpPartConfig]]
+   */
+  def httpPartConfigs: SortedSet[HttpPartConfig] = hystrixConfigs.flatMap(_.httpPartConfig).to[SortedSet]
 
 }
 
@@ -43,4 +50,5 @@ object ThreadPoolConfig {
     )
   }
 
+  implicit val order: Ordering[ThreadPoolConfig] = Ordering.by(_.threadPoolKey)
 }

--- a/app/com/m3/octoparts/repository/ConfigsRepository.scala
+++ b/app/com/m3/octoparts/repository/ConfigsRepository.scala
@@ -3,6 +3,7 @@ package com.m3.octoparts.repository
 import com.m3.octoparts.model.config._
 import com.twitter.zipkin.gen.Span
 
+import scala.collection.SortedSet
 import scala.concurrent.Future
 
 /**
@@ -14,42 +15,44 @@ import scala.concurrent.Future
  */
 trait ConfigsRepository {
   /**
-   * Wrapped version of a standard get operation that works much like Map#get
+   * Find a single [[HttpPartConfig]] by [[HttpPartConfig.partId]]
    */
   def findConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Option[HttpPartConfig]]
 
   /**
-   * Returns all the configs from the repository
+   * Returns all the configs from the repository, sorted by part_id.
+   * Dependent [[HttpPartConfig.hystrixConfig]], [[HystrixConfig.threadPoolConfig]], [[HttpPartConfig.cacheGroups]], [[HttpPartConfig.parameters]], [[PartParam.cacheGroups]] are populated
    */
-  def findAllConfigs()(implicit parentSpan: Span): Future[Seq[HttpPartConfig]]
+  def findAllConfigs()(implicit parentSpan: Span): Future[SortedSet[HttpPartConfig]]
 
+  /**
+   * Find a single [[PartParam]] by [[PartParam.id]]. Dependent [[PartParam.httpPartConfig]] and [[PartParam.cacheGroups]] are populated
+   */
   def findParamById(id: Long)(implicit parentSpan: Span): Future[Option[PartParam]]
 
   /**
-   * Find a single ThreadPoolConfig by id
+   * Find a single [[ThreadPoolConfig]] by [[ThreadPoolConfig.id]]. Dependent [[ThreadPoolConfig.hystrixConfigs]] and [[HystrixConfig.httpPartConfig]] are populated
    */
   def findThreadPoolConfigById(id: Long)(implicit parentSpan: Span): Future[Option[ThreadPoolConfig]]
 
   /**
-   * Return all the thread pool configs
-   *
-   * All retrieved items are populated with their [[HystrixConfig]]
+   * Return all the thread pool configs, sorted by key. Dependent [[ThreadPoolConfig.hystrixConfigs]] and [[HystrixConfig.httpPartConfig]] are populated
    */
-  def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[Seq[ThreadPoolConfig]]
+  def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[SortedSet[ThreadPoolConfig]]
 
   /**
-   * Returns a single cache group by name
+   * Returns a single [[CacheGroup]] by [[CacheGroup.name]]. Dependent [[CacheGroup.httpPartConfigs]], [[CacheGroup.partParams]], and [[PartParam.httpPartConfig]] are populated
    */
   def findCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Option[CacheGroup]]
 
   /**
-   * Return all cache groups
+   * Return all cache groups, sorted by name. Dependent [[CacheGroup.httpPartConfigs]], [[CacheGroup.partParams]], and [[PartParam.httpPartConfig]] are populated
    */
-  def findAllCacheGroups()(implicit parentSpan: Span): Future[Seq[CacheGroup]]
+  def findAllCacheGroups()(implicit parentSpan: Span): Future[SortedSet[CacheGroup]]
 
   /**
-   * Return all cache groups with the given names
+   * Return all cache groups with the given names. Dependent [[CacheGroup.httpPartConfigs]], [[CacheGroup.partParams]], and [[PartParam.httpPartConfig]] are populated
    */
-  def findAllCacheGroupsByName(name: String*)(implicit parentSpan: Span): Future[Seq[CacheGroup]]
+  def findAllCacheGroupsByName(name: String*)(implicit parentSpan: Span): Future[SortedSet[CacheGroup]]
 
 }

--- a/app/com/m3/octoparts/repository/DBConfigsRepository.scala
+++ b/app/com/m3/octoparts/repository/DBConfigsRepository.scala
@@ -1,7 +1,9 @@
 package com.m3.octoparts.repository
 
 import com.beachape.logging.LTSVLogger
+import com.beachape.zipkin.FutureEnrichment._
 import com.beachape.zipkin.services.ZipkinServiceLike
+import com.m3.octoparts.future.RichFutureWithTiming._
 import com.m3.octoparts.model.config._
 import com.m3.octoparts.repository.config._
 import com.twitter.zipkin.gen.Span
@@ -11,9 +13,8 @@ import scalikejdbc._
 import skinny.orm.SkinnyCRUDMapper
 import skinny.orm.feature.CRUDFeatureWithId
 import skinny.orm.feature.associations.Association
-import com.m3.octoparts.future.RichFutureWithTiming._
-import com.beachape.zipkin.FutureEnrichment._
 
+import scala.collection.SortedSet
 import scala.concurrent.{ Future, blocking }
 
 /**
@@ -57,28 +58,45 @@ trait ImmutableDBRepository extends ConfigsRepository {
 
   // Configs
   def findConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Option[HttpPartConfig]] = {
-    getWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId), includes = Seq(HttpPartConfigRepository.hystrixConfigRef))
+    // a hack to set the part parameter cache groups
+    // Since there is no reference in the PartParam object, the simplest way is to simply fetch all cache groups.
+    // They should be cached anyways.
+    val fMbPartConfig = getWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId), includes = Seq(HttpPartConfigRepository.hystrixConfigRef))
       .trace(s"$zipkinSpanNameBase-findConfigByPartId", "partId" -> partId)
+    val fCacheGroups = findAllCacheGroups()
+    for {
+      cacheGroups <- fCacheGroups
+      mbPartConfig <- fMbPartConfig
+    } yield {
+      mbPartConfig.map {
+        config =>
+          config.copy(parameters = config.parameters.map {
+            param => param.copy(cacheGroups = cacheGroups.filter(_.partParams.exists(_.id == param.id)))
+          })
+      }
+    }
   }
 
-  def findAllConfigs()(implicit parentSpan: Span): Future[Seq[HttpPartConfig]] = {
-    // a hack to set the part parameter cache groups
+  def findAllConfigs()(implicit parentSpan: Span): Future[SortedSet[HttpPartConfig]] = {
+    // a hack to set the part parameter cache groups. see explanation in #findConfigByPartId
+    val fCacheGroups = findAllCacheGroups()
+    val fConfigs = getAllWithSession(HttpPartConfigRepository, includes = Seq(HttpPartConfigRepository.hystrixConfigRef))
+      .trace(s"$zipkinSpanNameBase-findAllConfigs")
     for {
-      allCacheGroups <- findAllCacheGroups()
-      configs <- getAllWithSession(HttpPartConfigRepository, includes = Seq(HttpPartConfigRepository.hystrixConfigRef))
-        .trace(s"$zipkinSpanNameBase-findAllConfigs")
+      configs <- fConfigs
+      allCacheGroups <- fCacheGroups
     } yield {
       configs.map {
         config =>
-          config.copy(parameters = config.parameters.toSeq.map {
-            param => param.copy(cacheGroups = allCacheGroups.filter(_.partParams.exists(_.id == param.id)).toSet)
-          }.toSet)
+          config.copy(parameters = config.parameters.map {
+            param => param.copy(cacheGroups = allCacheGroups.filter(_.partParams.exists(_.id == param.id)))
+          })
       }
     }
   }
 
   def findParamById(id: Long)(implicit parentSpan: Span): Future[Option[PartParam]] = {
-    getWithSession(PartParamRepository, sqls.eq(PartParamRepository.defaultAlias.id, id), joins = Seq(PartParamRepository.httpPartConfigRef))
+    getWithSession(PartParamRepository, sqls.eq(PartParamRepository.defaultAlias.id, id), joins = Seq(PartParamRepository.httpPartConfigRef, PartParamRepository.cacheGroupsRef))
       .trace(s"$zipkinSpanNameBase-findParamById", "id" -> id.toString)
   }
 
@@ -88,27 +106,64 @@ trait ImmutableDBRepository extends ConfigsRepository {
       .trace(s"$zipkinSpanNameBase-findThreadPoolConfigById", "id" -> id.toString)
   }
 
-  def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[Seq[ThreadPoolConfig]] = {
+  def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[SortedSet[ThreadPoolConfig]] = {
     getAllWithSession(ThreadPoolConfigRepository, includes = Seq(ThreadPoolConfigRepository.hystrixConfigRef))
       .trace(s"$zipkinSpanNameBase-findAllThreadPoolConfigs")
   }
 
   // For CacheGroups
   def findCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Option[CacheGroup]] = {
-    getWithSession(CacheGroupRepository.withChildren, sqls.eq(CacheGroupRepository.defaultAlias.name, name))
-      .trace(s"$zipkinSpanNameBase-findCacheGroupByName", "name" -> name)
+    for {
+      mbCacheGroup <- getWithSession(CacheGroupRepository, sqls.eq(CacheGroupRepository.defaultAlias.name, name), joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
+        .trace(s"$zipkinSpanNameBase-findCacheGroupByName", "name" -> name)
+      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = mbCacheGroup.toSeq.map(populateCacheGroupPartParams)
+      populatedCacheGroups <- Future.sequence(fPopulateCacheGroupPartParams)
+    } yield {
+      populatedCacheGroups.headOption
+    }
   }
 
-  def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span): Future[Seq[CacheGroup]] = if (names.isEmpty) {
-    Future.successful(Nil)
+  def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span): Future[SortedSet[CacheGroup]] = if (names.isEmpty) {
+    Future.successful(SortedSet.empty)
   } else {
-    getAllByWithSession(CacheGroupRepository.withChildren, sqls.in(CacheGroupRepository.defaultAlias.name, names))
-      .trace(s"$zipkinSpanNameBase-findAllCacheGroupsByName", "names" -> names.toString)
+    for {
+      cacheGroups <- getAllByWithSession(CacheGroupRepository, sqls.in(CacheGroupRepository.defaultAlias.name, names), joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
+        .trace(s"$zipkinSpanNameBase-findAllCacheGroupsByName", "names" -> names.toString)
+      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = cacheGroups.toSeq.map(populateCacheGroupPartParams)
+      populatedCacheGroups <- Future.sequence(fPopulateCacheGroupPartParams)
+    } yield {
+      populatedCacheGroups.to[SortedSet]
+    }
   }
 
-  def findAllCacheGroups()(implicit parentSpan: Span): Future[Seq[CacheGroup]] = {
-    getAllWithSession(CacheGroupRepository.withChildren)
-      .trace(s"$zipkinSpanNameBase-findAllCacheGroups")
+  def findAllCacheGroups()(implicit parentSpan: Span): Future[SortedSet[CacheGroup]] = {
+    for {
+      cacheGroups <- getAllWithSession(CacheGroupRepository, joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
+        .trace(s"$zipkinSpanNameBase-findAllCacheGroups")
+      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = cacheGroups.toSeq.map(populateCacheGroupPartParams)
+      populatedCacheGroups <- Future.sequence(fPopulateCacheGroupPartParams)
+    } yield {
+      populatedCacheGroups.to[SortedSet]
+    }
+  }
+
+  /**
+   * AFAIK the ORM could not be twisted to fetch cacheGroup.partParam.httpPartConfig.
+   * This might make 1 request per member, but [[findParamById]] is cached.
+   */
+  private def populateCacheGroupPartParams(cacheGroup: CacheGroup)(implicit parentSpan: Span): Future[CacheGroup] = {
+    val fOptParams: Seq[Future[Option[PartParam]]] = for {
+      partParam <- cacheGroup.partParams.toSeq
+      paramId <- partParam.id.toSeq
+    } yield {
+      findParamById(paramId)
+    }
+
+    for {
+      optParams <- Future.sequence(fOptParams)
+    } yield {
+      cacheGroup.copy(partParams = optParams.flatten.to[SortedSet])
+    }
   }
 
   /**
@@ -130,12 +185,12 @@ trait ImmutableDBRepository extends ConfigsRepository {
   /**
    * Gets all the records from a table and logs the number of records retrieved
    */
-  private[repository] def getAllWithSession[A](mapper: CRUDFeatureWithId[Long, A],
-                                               joins: Seq[Association[_]] = Nil,
-                                               includes: Seq[Association[_]] = Nil)(implicit session: DBSession = ReadOnlyAutoSession): Future[Seq[A]] = Future {
+  private[repository] def getAllWithSession[A: Ordering](mapper: CRUDFeatureWithId[Long, A],
+                                                         joins: Seq[Association[_]] = Nil,
+                                                         includes: Seq[Association[_]] = Nil)(implicit session: DBSession = ReadOnlyAutoSession): Future[SortedSet[A]] = Future {
     blocking {
-      val ret = mapper.joins(joins: _*).includes(includes: _*).findAll()
-      LTSVLogger.debug("Table" -> mapper.tableName, "Retrieved records" -> ret.length.toString)
+      val ret = mapper.joins(joins: _*).includes(includes: _*).findAll().to[SortedSet]
+      LTSVLogger.debug("Table" -> mapper.tableName, "Retrieved records" -> ret.size.toString)
       ret
     }
   }.measure("DB_GET")
@@ -143,20 +198,20 @@ trait ImmutableDBRepository extends ConfigsRepository {
   /**
    * Gets all the records from a table according to a where clause and logs the number of records retrieved
    */
-  private[repository] def getAllByWithSession[A](mapper: CRUDFeatureWithId[Long, A],
-                                                 where: SQLSyntax,
-                                                 joins: Seq[Association[_]] = Nil,
-                                                 includes: Seq[Association[_]] = Nil)(implicit session: DBSession = ReadOnlyAutoSession): Future[Seq[A]] = Future {
+  private[repository] def getAllByWithSession[A: Ordering](mapper: CRUDFeatureWithId[Long, A],
+                                                           where: SQLSyntax,
+                                                           joins: Seq[Association[_]] = Nil,
+                                                           includes: Seq[Association[_]] = Nil)(implicit session: DBSession = ReadOnlyAutoSession): Future[SortedSet[A]] = Future {
     blocking {
-      val ret = mapper.joins(joins: _*).includes(includes: _*).findAllBy(where)
-      LTSVLogger.debug("Table" -> mapper.tableName, "Retrieved records" -> ret.length.toString)
+      val ret = mapper.joins(joins: _*).includes(includes: _*).findAllBy(where).to[SortedSet]
+      LTSVLogger.debug("Table" -> mapper.tableName, "Retrieved records" -> ret.size.toString)
       ret
     }
   }.measure("DB_GET")
 }
 
 trait MutableDBRepository extends MutableConfigsRepository {
-  import DBContext._
+  import com.m3.octoparts.repository.DBContext._
 
   implicit def zipkinService: ZipkinServiceLike
   private val zipkinSpanNameBase = "db-repo-mutation"

--- a/app/com/m3/octoparts/repository/RepositoriesModule.scala
+++ b/app/com/m3/octoparts/repository/RepositoriesModule.scala
@@ -24,7 +24,7 @@ class RepositoriesModule extends Module {
         val bufferingCache = new MemoryBufferingRawCache(networkCache, localBufferDuration.millis)
         new MemcachedCache(bufferingCache, MemcachedKeyGenerator)
       }
-      case None => inject[Cache]
+      case _ => inject[Cache]
     }
 
     new MutableCachingRepository(

--- a/app/com/m3/octoparts/repository/config/ExtraParamType.scala
+++ b/app/com/m3/octoparts/repository/config/ExtraParamType.scala
@@ -2,6 +2,7 @@ package com.m3.octoparts.repository.config
 
 import skinny.AbstractParamType
 
+import scala.collection.SortedSet
 import scala.concurrent.duration.FiniteDuration
 
 object ExtraParamType {
@@ -14,9 +15,9 @@ object ExtraParamType {
     case d: FiniteDuration => d.toMillis
   })
 
-  case object IntSetParamType extends AbstractParamType({
-    // this will actually be a Set[Int] but the compiler complains about it.
-    case s: Set[_] => s.mkString(",")
+  case object IntSortedSetParamType extends AbstractParamType({
+    // this will actually be a Seq[Int] but the compiler complains about it.
+    case s: SortedSet[_] => s.mkString(",")
   })
 
 }

--- a/app/com/m3/octoparts/repository/config/HttpPartConfigCacheGroupRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HttpPartConfigCacheGroupRepository.scala
@@ -5,8 +5,8 @@ import skinny.orm.SkinnyJoinTable
 
 object HttpPartConfigCacheGroupRepository extends SkinnyJoinTable[HttpPartConfigCacheGroup] {
 
-  override lazy val defaultAlias = createAlias("http_part_config_cache_group")
+  lazy val defaultAlias = createAlias("http_part_config_cache_group")
 
-  override lazy val tableName = "http_part_config_cache_group"
+  override val tableName = "http_part_config_cache_group"
 
 }

--- a/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
@@ -26,7 +26,7 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
   // #byDefault is used for now in case we ever need to refer back to the HttpPartConfig
   // to which this HystrixConfig belongs
   lazy val httpPartConfigOpt = belongsToWithFk[HttpPartConfig](
-    HttpPartConfigRepository, "httpPartConfigId", (h, c) => h.copy(httpPartConfig = c))
+    HttpPartConfigRepository, "httpPartConfigId", (hc, mbHpc) => hc.copy(httpPartConfig = mbHpc))
 
   /*
     #byDefault should always be used here because we need to be able to eager load the thread
@@ -38,7 +38,7 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
     ).includes[ThreadPoolConfig](merge = (hystrixConfigs, threadConfigs) =>
         hystrixConfigs.map { h =>
           threadConfigs.collectFirst {
-            case t if h.threadPoolConfigId == t.id => h.copy(threadPoolConfig = Some(t))
+            case tpc if h.threadPoolConfigId == tpc.id => h.copy(threadPoolConfig = Some(tpc))
           }.getOrElse(h)
         }
       )

--- a/app/com/m3/octoparts/repository/config/PartParamCacheGroupRepository.scala
+++ b/app/com/m3/octoparts/repository/config/PartParamCacheGroupRepository.scala
@@ -5,8 +5,8 @@ import skinny.orm.SkinnyJoinTable
 
 object PartParamCacheGroupRepository extends SkinnyJoinTable[PartParamCacheGroup] {
 
-  override lazy val defaultAlias = createAlias("part_param_cache_group")
+  lazy val defaultAlias = createAlias("part_param_cache_group")
 
-  override lazy val tableName = "part_param_cache_group"
+  override val tableName = "part_param_cache_group"
 
 }

--- a/app/com/m3/octoparts/repository/config/ThreadPoolConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/ThreadPoolConfigRepository.scala
@@ -5,13 +5,15 @@ import scalikejdbc._
 import skinny.orm.feature.TimestampsFeature
 import skinny.{ ParamType => SkinnyParamType }
 
+import scala.collection.SortedSet
+
 object ThreadPoolConfigRepository extends ConfigMapper[ThreadPoolConfig] with TimestampsFeature[ThreadPoolConfig] {
 
-  override lazy val defaultAlias = createAlias("thread_pool_config")
+  lazy val defaultAlias = createAlias("thread_pool_config")
 
-  override lazy val tableName = "thread_pool_config"
+  override val tableName = "thread_pool_config"
 
-  override val permittedFields = Seq(
+  protected val permittedFields = Seq(
     "threadPoolKey" -> SkinnyParamType.String,
     "coreSize" -> SkinnyParamType.Int
   )
@@ -21,8 +23,8 @@ object ThreadPoolConfigRepository extends ConfigMapper[ThreadPoolConfig] with Ti
     // defines join condition by using aliases
     on = (t, h) => sqls.eq(t.id, h.threadPoolConfigId),
     // function to merge associations to main entity
-    merge = (t, h) => t.copy(hystrixConfigs = h)
-  ).includes[HystrixConfig]((ts, hs) => ts.map(t => t.copy(hystrixConfigs = hs.filter(_.threadPoolConfigId == t.id))))
+    merge = (tpc, hcs) => tpc.copy(hystrixConfigs = hcs.toSet)
+  ).includes[HystrixConfig]((tpcs, hcs) => tpcs.map(tpc => tpc.copy(hystrixConfigs = hcs.filter(_.threadPoolConfigId == tpc.id).toSet)))
 
   def extract(rs: WrappedResultSet, n: ResultName[ThreadPoolConfig]) = ThreadPoolConfig(
     id = rs.get(n.id),

--- a/app/com/m3/octoparts/util/KeyedResourcePool.scala
+++ b/app/com/m3/octoparts/util/KeyedResourcePool.scala
@@ -56,12 +56,12 @@ trait KeyedResourcePool[K, V] {
    *
    * @param validKeys all keys that you want to keep
    */
-  final def cleanObsolete(validKeys: Set[K]): Unit = {
+  final def cleanObsolete(validKeys: K => Boolean): Unit = {
     wlock.lock()
     try {
       holder.foreach {
         case (key, value) =>
-          if (!validKeys.contains(key)) {
+          if (!validKeys(key)) {
             holder = holder - key
             onRemove(value)
           }

--- a/app/controllers/AdminForms.scala
+++ b/app/controllers/AdminForms.scala
@@ -9,6 +9,7 @@ import org.joda.time.DateTime
 import play.api.data.Forms._
 import play.api.data._
 
+import scala.collection.SortedSet
 import scala.concurrent.duration._
 
 object AdminForms {
@@ -32,13 +33,13 @@ object AdminForms {
     data =>
 
     /** Create a brand new HttpPartConfig using the data input into the form */
-    def toNewHttpPartConfig(owner: String, cacheGroups: Set[CacheGroup]): HttpPartConfig = HttpPartConfig(
+    def toNewHttpPartConfig(owner: String, cacheGroups: SortedSet[CacheGroup]): HttpPartConfig = HttpPartConfig(
       partId = PartData.trimPartId(data.partId),
       owner = owner,
       description = data.description,
       uriToInterpolate = data.httpSettings.uri,
       method = HttpMethod.withName(data.httpSettings.method),
-      additionalValidStatuses = HttpPartConfig.parseValidStatuses(data.httpSettings.additionalValidStatuses.filterNot(_.isEmpty)),
+      additionalValidStatuses = HttpPartConfig.parseValidStatuses(data.httpSettings.additionalValidStatuses),
       httpPoolSize = data.httpSettings.httpPoolSize,
       httpConnectionTimeout = data.httpSettings.httpConnectionTimeoutInMs.milliseconds,
       httpSocketTimeout = data.httpSettings.httpSocketTimeoutInMs.milliseconds,
@@ -68,13 +69,12 @@ object AdminForms {
     )
 
     /** Update an existing HttpPartConfig using the data input into the form */
-    def toUpdatedHttpPartConfig(originalPart: HttpPartConfig, params: Set[PartParam], cacheGroups: Set[CacheGroup]): HttpPartConfig = originalPart.copy(
+    def toUpdatedHttpPartConfig(originalPart: HttpPartConfig, cacheGroups: SortedSet[CacheGroup]): HttpPartConfig = originalPart.copy(
       partId = PartData.trimPartId(data.partId),
-      parameters = params,
       description = data.description,
       uriToInterpolate = data.httpSettings.uri,
       method = HttpMethod.withName(data.httpSettings.method),
-      additionalValidStatuses = HttpPartConfig.parseValidStatuses(data.httpSettings.additionalValidStatuses.filterNot(_.isEmpty)),
+      additionalValidStatuses = HttpPartConfig.parseValidStatuses(data.httpSettings.additionalValidStatuses),
       httpPoolSize = data.httpSettings.httpPoolSize,
       httpConnectionTimeout = data.httpSettings.httpConnectionTimeoutInMs.milliseconds,
       httpSocketTimeout = data.httpSettings.httpSocketTimeoutInMs.milliseconds,
@@ -126,7 +126,7 @@ object AdminForms {
         localContentsAsFallback = part.hystrixConfigItem.localContentsAsFallback
       ),
       ttl = part.cacheTtl.map(_.toSeconds.toInt),
-      cacheGroupNames = part.cacheGroups.map(_.name).toSeq,
+      cacheGroupNames = part.cacheGroups.toSeq.map(_.name),
       alertMailData = AlertMailData(
         enabled = part.alertMailsEnabled,
         interval = Some(part.alertInterval.toSeconds.toInt),

--- a/app/controllers/CacheController.scala
+++ b/app/controllers/CacheController.scala
@@ -100,7 +100,7 @@ class CacheController(cacheOps: CacheOps, repository: ConfigsRepository)
     }
   }
 
-  private def checkResult(fu: Future[Unit])(implicit request: RequestHeader): Future[Result] = {
+  private def checkResult(fu: Future[_])(implicit request: RequestHeader): Future[Result] = {
     fu.map(_ => Ok("OK")).recover(logAndRenderError("ERROR: " + _.toString))
   }
 
@@ -121,26 +121,16 @@ class CacheController(cacheOps: CacheOps, repository: ConfigsRepository)
   /**
    * Invalidates the given group's PartParams
    *
-   * Does a fetch of each PartParam that is on the CacheGroup because
-   * 1. These may be stale because CacheGroups are cached (unlikely)
-   * 2. We CANNOT assume that PartParams from CacheGroup#partParams have their parent HttpPartConfig
-   * readily available
-   *
    * @return Future sequence of partParam names that were invalidated
    */
-  private def invalidateGroupPartParams(group: CacheGroup, paramValue: String)(implicit parentSpan: Span): Future[Seq[String]] = {
-    val futureMaybeParamSeq = Future.sequence(group.partParams.map(_.id).flatten.map(repository.findParamById))
-    futureMaybeParamSeq.flatMap { maybeParamSeq =>
-      Future.sequence(for {
-        maybeParam <- maybeParamSeq
-        param <- maybeParam
-        partConfig <- param.httpPartConfig // Safe to assume at this point that they exist
-      } yield {
-        cacheOps.increaseParamVersion(VersionedParamKey(partConfig.partId, param.outputName, paramValue)).map { done =>
-          param.outputName
-        }
-      }
-      )
+  private def invalidateGroupPartParams(group: CacheGroup, paramValue: String)(implicit parentSpan: Span): Future[Seq[String]] = Future.sequence {
+    for {
+      param <- group.partParams.toSeq
+      partConfig <- param.httpPartConfig // Safe to assume at this point that they exist
+    } yield {
+      val vpk = VersionedParamKey(partConfig.partId, param.outputName, paramValue)
+      val ipv: Future[_] = cacheOps.increaseParamVersion(vpk)
+      ipv.map(_ => param.outputName)
     }
   }
 
@@ -148,10 +138,13 @@ class CacheController(cacheOps: CacheOps, repository: ConfigsRepository)
    * Invalidates the given group's parts
    * @return Future sequence of Part names that were invalidated
    */
-  private def invalidateGroupParts(group: CacheGroup)(implicit parentSpan: Span): Future[Seq[String]] = Future.sequence(for {
-    part <- group.httpPartConfigs
-  } yield {
-    cacheOps.increasePartVersion(part.partId).map(done => part.partId)
-  })
+  private def invalidateGroupParts(group: CacheGroup)(implicit parentSpan: Span): Future[Seq[String]] = Future.sequence {
+    for {
+      part <- group.httpPartConfigs.toSeq
+    } yield {
+      val ipv: Future[_] = cacheOps.increasePartVersion(part.partId)
+      ipv.map(_ => part.partId)
+    }
+  }
 
 }

--- a/app/controllers/system/HealthcheckController.scala
+++ b/app/controllers/system/HealthcheckController.scala
@@ -57,7 +57,7 @@ class HealthcheckController(configsRepo: ConfigsRepository,
    * Check that the DB connection is alive and there is at least one part registered in the system
    */
   private def checkDb()(implicit parentSpan: Span): Future[DbStatus] = {
-    val fCount = configsRepo.findAllConfigs().map(_.length)
+    val fCount = configsRepo.findAllConfigs().map(_.size)
     fCount.map { count =>
       if (count > 0) DbStatus(ok = true, message = "DB looks fine")
       else DbStatus(ok = false, message = "parts_config table is empty!")

--- a/app/presentation/ParamView.scala
+++ b/app/presentation/ParamView.scala
@@ -11,7 +11,9 @@ case class ParamView(param: PartParam) {
 
   def requiredCls: String = if (required) "required" else "optional"
 
-  def name: String = param.outputName
+  def name: String = param.inputNameOverride.getOrElse(param.outputName)
+
+  def outputName: String = param.outputName
 
   def paramType = param.paramType.toString
 
@@ -22,4 +24,8 @@ case class ParamView(param: PartParam) {
   def description = param.description
 
   def inputNameJs = StringEscapeUtils.escapeJavaScript(param.inputName)
+}
+
+object ParamView {
+  implicit val order: Ordering[ParamView] = Ordering.by(_.param)
 }

--- a/app/views/cachegroup/list.scala.html
+++ b/app/views/cachegroup/list.scala.html
@@ -1,4 +1,4 @@
-@(cacheGroups: Seq[com.m3.octoparts.model.config.CacheGroup])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
+@(cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
 
 @views.html.adminlayout(Messages("cacheGroups.list")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/app/views/param/edit.scala.html
+++ b/app/views/param/edit.scala.html
@@ -1,6 +1,6 @@
 @(partId: String,
-  cacheGroups: Seq[com.m3.octoparts.model.config.CacheGroup],
-  selectedCacheGroupIds: Set[Long],
+  cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup],
+  selectedCacheGroupIds: Long => Boolean,
   maybeParam: Option[presentation.ParamView])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
 
     @title = @{
@@ -49,7 +49,7 @@
             <div class="row">
                 <div class="col-sm-5">
                     <select name="paramType" class="form-control">
-                        @for(outputType <- com.m3.octoparts.model.config.ParamType.values.toSeq) {
+                        @for(outputType <- com.m3.octoparts.model.config.ParamType.values) {
                             <option value="@outputType" @if(maybeParam.exists(_.param.paramType == outputType)) { selected="selected" } >@outputType</option>
                         }
                     </select>
@@ -89,8 +89,8 @@
                 @Messages("parameter.cacheGroups.none")
             } else {
                 <select name="cacheGroups[]" multiple>
-                    @for(cacheGroup <- cacheGroups) {
-                        <option value="@cacheGroup.name" @if(selectedCacheGroupIds.contains(cacheGroup.id.get)) { selected="selected" }>@cacheGroup.name</option>
+                    @for(cacheGroup <- cacheGroups; cacheGroupId <- cacheGroup.id) {
+                        <option value="@cacheGroup.name" @if(selectedCacheGroupIds(cacheGroupId)) { selected="selected" }>@cacheGroup.name</option>
                     }
                 </select>
             }

--- a/app/views/part/edit.scala.html
+++ b/app/views/part/edit.scala.html
@@ -1,6 +1,6 @@
 @(form: Form[controllers.AdminForms.PartData],
-  threadPoolConfigs: Seq[com.m3.octoparts.model.config.ThreadPoolConfig],
-  cacheGroups: Seq[com.m3.octoparts.model.config.CacheGroup],
+  threadPoolConfigs: scala.collection.SortedSet[com.m3.octoparts.model.config.ThreadPoolConfig],
+  cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup],
   maybePart: Option[com.m3.octoparts.model.config.HttpPartConfig])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
 
 @* Override the default field constructor and use our simple one instead *@
@@ -240,7 +240,10 @@
                     <div class="col-sm-5">
                         @helper.select(
                             field = form("hystrixConfig.threadPoolConfigId"),
-                            options = threadPoolConfigs.map(tpc => (tpc.id.get.toString, s"${tpc.threadPoolKey} (core size: ${tpc.coreSize})")),
+                            options = for {
+                                tpc <- threadPoolConfigs.toSeq
+                                tpcId <- tpc.id
+                            } yield (tpcId.toString, s"${tpc.threadPoolKey} (core size: ${tpc.coreSize})"),
                             args = 'class -> "form-control validate[required]")
                     </div>
                 </div>
@@ -296,7 +299,7 @@
                     } else {
                         @helper.select(
                             field = form("cacheGroupNames"),
-                            options = cacheGroups.map(cg => (cg.name, cg.name)),
+                            options = cacheGroups.toSeq.map(cg => (cg.name, cg.name)),
                             args = 'multiple -> "")
                     }
                     </div>

--- a/app/views/part/list.scala.html
+++ b/app/views/part/list.scala.html
@@ -1,4 +1,4 @@
-@(parts: Seq[presentation.HttpPartConfigView])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
+@(parts: scala.collection.SortedSet[presentation.HttpPartConfigView])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
 
 @views.html.adminlayout(Messages("parts.list")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/app/views/part/show.scala.html
+++ b/app/views/part/show.scala.html
@@ -56,7 +56,7 @@
         <dd>@part.httpMethod</dd>
         @if(part.config.additionalValidStatuses.nonEmpty) {
             <dt>@Messages("parts.additionalValidStatuses")</dt>
-            <dd>@Messages("parts.additionalValidStatuses.wrap", part.config.additionalValidStatuses.mkString(", "))</dd>
+            <dd>@Messages("parts.additionalValidStatuses.wrap", part.additionalValidStatuses)</dd>
         }
         <dt>@Messages("parts.httpPoolSize")</dt>
         <dd>@part.config.httpPoolSize</dd>
@@ -85,10 +85,10 @@
                     </tr>
                 </thead>
                 <tbody>
-                @for(paramView <- part.registeredParamsView) {
+                @for(paramView <- part.registeredParamsView; paramId <- paramView.param.id) {
                     <tr>
+                        <td>@paramView.outputName</td>
                         <td>@paramView.name</td>
-                        <td>@paramView.param.inputName</td>
                         <td>@paramView.paramType</td>
                         <td>@paramView.required</td>
                         <td style="white-space: pre">@paramView.description</td>
@@ -96,11 +96,11 @@
                         <td><ul>@for(cacheGroup <- paramView.param.cacheGroups) {
                             <li><a href="@controllers.routes.AdminController.showCacheGroup(cacheGroup.name)">@cacheGroup.name</a></li>
                         }</ul></td>
-                        <td><a href="@controllers.routes.AdminController.editParam(part.partId, paramView.param.id.get)" class="btn btn-primary">@Messages("edit")</a>
-                            <form action="@controllers.routes.AdminController.copyParam(part.partId, paramView.param.id.get)" method="post">
+                        <td><a href="@controllers.routes.AdminController.editParam(part.partId, paramId)" class="btn btn-primary">@Messages("edit")</a>
+                            <form action="@controllers.routes.AdminController.copyParam(part.partId, paramId)" method="post">
                                 <input type="submit" value="@Messages("duplicate")" class="btn btn-info" />
                             </form>
-                            <a href="@controllers.routes.AdminController.confirmDeleteParam(part.partId, paramView.param.id.get)" class="btn btn-danger">@Messages("delete")</a>
+                            <a href="@controllers.routes.AdminController.confirmDeleteParam(part.partId, paramId)" class="btn btn-danger">@Messages("delete")</a>
                         </td>
                     </tr>
                 }

--- a/app/views/threadpool/list.scala.html
+++ b/app/views/threadpool/list.scala.html
@@ -1,4 +1,4 @@
-@(threadPoolConfigs: Seq[com.m3.octoparts.model.config.ThreadPoolConfig])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
+@(threadPoolConfigs: scala.collection.SortedSet[com.m3.octoparts.model.config.ThreadPoolConfig])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, lang: Lang)
 
 @views.html.adminlayout(Messages("threadPools.list")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/app/views/threadpool/show.scala.html
+++ b/app/views/threadpool/show.scala.html
@@ -29,7 +29,7 @@
             </tr>
         </thead>
         <tbody>
-        @for(part <- tpc.hystrixConfigs.flatMap(_.httpPartConfig)) {
+        @for(part <- tpc.httpPartConfigs) {
             <tr>
                 <td><a href="@{controllers.routes.AdminController.showPart(part.partId).url}">@part.partId</a></td>
             </tr>

--- a/java-client/src/test/scala/com/m3/octoparts/client/ExtractorsSpec.scala
+++ b/java-client/src/test/scala/com/m3/octoparts/client/ExtractorsSpec.scala
@@ -4,8 +4,8 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 
 import com.m3.octoparts.model.config.json._
-import com.m3.octoparts.model.{ HttpMethod, ResponseMeta, AggregateResponse }
-import org.scalatest.{ Matchers, FunSpec }
+import com.m3.octoparts.model.{ AggregateResponse, HttpMethod, ResponseMeta }
+import org.scalatest.{ FunSpec, Matchers }
 
 import scala.collection.convert.Wrappers.SeqWrapper
 import scala.concurrent.duration._
@@ -22,10 +22,24 @@ class ExtractorsSpec extends FunSpec with Matchers {
   }
   describe("EndpointListExtractor") {
     it("should extract something that has just been serialized") {
-      val configs = Seq(HttpPartConfig("p", "me", "http://localhost", Some(""),
-        HttpMethod.Post, HystrixConfig(5.seconds, ThreadPoolConfig("knitty", 1, 10), "p", "knitty", true),
-        httpPoolSize = 5, httpConnectionTimeout = 1.second, httpSocketTimeout = 5.seconds, httpDefaultEncoding = StandardCharsets.UTF_8,
-        alertMailSettings = AlertMailSettings.Off))
+      val configs = Seq(
+        HttpPartConfig(
+          partId = "p",
+          owner = "me",
+          uriToInterpolate = "http://localhost",
+          description = Some(""),
+          method = HttpMethod.Post,
+          hystrixConfig = HystrixConfig(5.seconds, ThreadPoolConfig("knitty", 1, 10), "p", "knitty", localContentsAsFallback = true),
+          additionalValidStatuses = Set.empty,
+          httpPoolSize = 5,
+          httpConnectionTimeout = 1.second,
+          httpSocketTimeout = 5.seconds,
+          httpDefaultEncoding = StandardCharsets.UTF_8,
+          parameters = Set.empty,
+          cacheGroups = Set.empty,
+          alertMailSettings = AlertMailSettings.Off
+        )
+      )
       val serialized = OctopartsApiBuilder.Mapper.writeValueAsBytes(configs)
       EndpointListExtractor.deserialize(new ByteArrayInputStream(serialized)) should equal(SeqWrapper(configs))
     }

--- a/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
@@ -58,7 +58,7 @@ case class ResponseMeta(@(ApiModelProperty @field)(required = true)@BeanProperty
  */
 case class PartResponse(@(ApiModelProperty @field)(required = true)@BeanProperty partId: String,
                         @(ApiModelProperty @field)(required = true)@BeanProperty id: String,
-                        @BeanProperty cookies: Seq[Cookie] = Seq.empty,
+                        @BeanProperty cookies: Seq[Cookie] = Nil,
                         @(ApiModelProperty @field)(required = false, dataType = "integer")@BeanProperty statusCode: Option[Int] = None,
                         @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty mimeType: Option[String] = None,
                         @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty charset: Option[String] = None,

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/AlertMailSettings.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/AlertMailSettings.scala
@@ -13,5 +13,5 @@ case class AlertMailSettings(
   @(ApiModelProperty @field)(dataType = "string", required = false) alertMailRecipients: Option[String] = None)
 
 object AlertMailSettings {
-  val Off = AlertMailSettings(alertInterval = 0.second)
+  val Off = AlertMailSettings(alertInterval = Duration.Zero)
 }

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/CacheGroup.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/CacheGroup.scala
@@ -7,3 +7,7 @@ import scala.annotation.meta.field
 case class CacheGroup(@(ApiModelProperty @field)(required = true) name: String,
                       @(ApiModelProperty @field)(required = true) owner: String,
                       @(ApiModelProperty @field)(required = true) description: String)
+
+object CacheGroup {
+  implicit val order: Ordering[CacheGroup] = Ordering.by(_.name)
+}

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/HttpPartConfig.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/HttpPartConfig.scala
@@ -17,16 +17,20 @@ case class HttpPartConfig(
   @(ApiModelProperty @field)(required = false, dataType = "string") description: Option[String],
   @(ApiModelProperty @field)(dataType = "string", allowableValues = "get, post, put, delete, head, patch, options")@JsonScalaEnumeration(classOf[HttpMethodType]) method: HttpMethod.Value,
   @(ApiModelProperty @field)(required = true) hystrixConfig: HystrixConfig,
-  @(ApiModelProperty @field)(dataType = "array[integer]") additionalValidStatuses: Set[Int] = Set.empty,
+  @(ApiModelProperty @field)(dataType = "array[integer]") additionalValidStatuses: Set[Int],
   @(ApiModelProperty @field)(required = true, dataType = "integer", allowableValues = "range[1, Infinity]") httpPoolSize: Int,
   @(ApiModelProperty @field)(required = true, dataType = "integer", allowableValues = "range[0, Infinity]") httpConnectionTimeout: FiniteDuration,
   @(ApiModelProperty @field)(required = true, dataType = "integer", allowableValues = "range[0, Infinity]") httpSocketTimeout: FiniteDuration,
   @(ApiModelProperty @field)(required = true, dataType = "string") httpDefaultEncoding: Charset,
   @(ApiModelProperty @field)(required = false, dataType = "string") httpProxy: Option[String] = None,
-  parameters: Set[PartParam] = Set.empty,
+  parameters: Set[PartParam],
   @(ApiModelProperty @field)(dataType = "string", required = false) deprecatedInFavourOf: Option[String] = None,
-  cacheGroups: Set[CacheGroup] = Set.empty,
+  cacheGroups: Set[CacheGroup],
   @(ApiModelProperty @field)(dataType = "integer", required = false, allowableValues = "range[0, Infinity]", value = "in ms") cacheTtl: Option[FiniteDuration] = Some(Duration.Zero),
   alertMailSettings: AlertMailSettings,
   @(ApiModelProperty @field)(required = true) localContentsEnabled: Boolean = false,
   @(ApiModelProperty @field)(dataType = "string", required = false) localContents: Option[String] = None)
+
+object HttpPartConfig {
+  implicit val order: Ordering[HttpPartConfig] = Ordering.by(_.partId)
+}

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/HystrixConfig.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/HystrixConfig.scala
@@ -10,3 +10,7 @@ case class HystrixConfig(@(ApiModelProperty @field)(required = true, dataType = 
                          @(ApiModelProperty @field)(required = true) commandKey: String,
                          @(ApiModelProperty @field)(required = true) commandGroupKey: String,
                          @(ApiModelProperty @field)(required = true) localContentsAsFallback: Boolean)
+
+object HystrixConfig {
+  implicit val order: Ordering[HystrixConfig] = Ordering.by(_.commandKey)
+}

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/PartParam.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/PartParam.scala
@@ -12,6 +12,10 @@ case class PartParam(
   @(ApiModelProperty @field)(required = true) versioned: Boolean,
   @(ApiModelProperty @field)(required = true, dataType = "string", allowableValues = "query, path, header, cookie, body")@JsonScalaEnumeration(classOf[ParamTypeType]) paramType: ParamType.Value,
   @(ApiModelProperty @field)(required = true) outputName: String,
-  @(ApiModelProperty @field)(required = false, dataType = "string") description: Option[String] = None,
-  @(ApiModelProperty @field)(required = false, dataType = "string") inputNameOverride: Option[String] = None,
-  cacheGroups: Set[CacheGroup] = Set.empty)
+  @(ApiModelProperty @field)(required = false, dataType = "string") description: Option[String],
+  @(ApiModelProperty @field)(required = false, dataType = "string") inputNameOverride: Option[String],
+  cacheGroups: Set[CacheGroup])
+
+object PartParam {
+  implicit val order: Ordering[PartParam] = Ordering.by(pp => (pp.outputName, pp.paramType))
+}

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/OctoClientSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/OctoClientSpec.scala
@@ -2,26 +2,26 @@ package com.m3.octoparts.ws
 
 import java.nio.charset.StandardCharsets
 
-import com.m3.octoparts.json.format.ReqResp._
 import com.m3.octoparts.json.format.ConfigModel._
+import com.m3.octoparts.json.format.ReqResp._
 import com.m3.octoparts.model._
 import com.m3.octoparts.model.config.ParamType
 import com.m3.octoparts.model.config.json._
-import play.api.libs.json._
-import org.scalatest._
-import org.scalatest.concurrent.{ Eventually, IntegrationPatience, PatienceConfiguration, ScalaFutures }
-import org.scalatest.mock.MockitoSugar
-import play.api.libs.json.JsValue
-import play.api.libs.ws._
-import org.mockito.Mockito._
 import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest._
+import org.scalatest.concurrent._
+import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.{ JsValue, _ }
+import play.api.libs.ws._
 import play.api.mvc.RequestHeader
 import play.api.mvc.Results.EmptyContent
 import play.api.test.FakeRequest
 
-import scala.language.postfixOps
+import scala.collection.SortedSet
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class OctoClientSpec
     extends FunSpec
@@ -88,7 +88,7 @@ class OctoClientSpec
           queueSize = 256),
         commandKey = "command",
         commandGroupKey = "GroupKey",
-        false),
+        localContentsAsFallback = false),
       additionalValidStatuses = Set(302),
       httpPoolSize = 20,
       httpConnectionTimeout = 1.second,
@@ -98,12 +98,14 @@ class OctoClientSpec
         PartParam(
           required = true,
           versioned = false,
+          description = Some("!!"),
           paramType = ParamType.Header,
           outputName = "userId",
           inputNameOverride = None,
           cacheGroups = Set.empty
         )),
       deprecatedInFavourOf = None,
+      cacheGroups = Set.empty,
       cacheTtl = Some(60 seconds),
       alertMailSettings = AlertMailSettings(
         alertMailsEnabled = true,
@@ -230,10 +232,10 @@ class OctoClientSpec
         val subject = new OctoClientLike {
           val baseUrl = "http://bobby.com"
           def wsHolderFor(url: String, timeout: FiniteDuration): WSRequestHolder = wsHolderCreator.apply(url)
-          def rescuer[A](obj: => A): PartialFunction[Throwable, A] = PartialFunction.empty
+          protected def rescuer[A](obj: => A): PartialFunction[Throwable, A] = PartialFunction.empty
           protected val clientTimeout = 10 seconds
-          protected def rescueAggregateResponse: AggregateResponse = emptyReqResponse
-          protected def rescueHttpPartConfigs: Seq[HttpPartConfig] = Seq.empty
+          protected def rescueAggregateResponse = emptyReqResponse
+          protected def rescueHttpPartConfigs = Nil
         }
         block(subject)
         eventually(verify(wsHolderCreator, times(howManyTimes)).apply(url))

--- a/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
+++ b/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
@@ -9,8 +9,8 @@ import com.m3.octoparts.hystrix.{ HystrixExecutor, MockHttpClientComponent }
 import com.m3.octoparts.model.HttpMethod.Get
 import com.m3.octoparts.model.config.ParamType._
 import com.m3.octoparts.model.config._
-import com.twitter.zipkin.gen.Span
 import com.m3.octoparts.model.{ PartRequest, PartResponse, RequestMeta }
+import com.twitter.zipkin.gen.Span
 import org.apache.http.HttpStatus
 import org.apache.http.client.methods.HttpUriRequest
 import org.scalatest._
@@ -157,7 +157,7 @@ class HttpPartRequestHandlerSpec extends FunSpec with Matchers with ScalaFutures
         override def future[T](f: => T, fallbackTransform: Option[String] => T) = Future.successful(f)
       }
       def httpMethod = Get
-      val additionalValidStatuses = Set.empty[Int]
+      protected val additionalValidStatuses = Set.empty[Int]
       def httpClient = client
     }
   }

--- a/test/com/m3/octoparts/aggregator/service/PartRequestServiceSpec.scala
+++ b/test/com/m3/octoparts/aggregator/service/PartRequestServiceSpec.scala
@@ -1,20 +1,20 @@
 package com.m3.octoparts.aggregator.service
 
 import com.beachape.zipkin.services.NoopZipkinService
+import com.m3.octoparts.aggregator.PartRequestInfo
+import com.m3.octoparts.model._
+import com.m3.octoparts.model.config.{ HttpPartConfig, PartParam }
+import com.m3.octoparts.repository.ConfigsRepository
+import com.m3.octoparts.support.mocks.HandlerMocks
 import com.twitter.zipkin.gen.Span
-import org.mockito.Matchers._
-import org.mockito.Matchers.{ eq => mockitoEq }
+import org.mockito.Matchers.{ eq => mockitoEq, _ }
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 
-import com.m3.octoparts.model._
-import com.m3.octoparts.repository.ConfigsRepository
-import com.m3.octoparts.support.mocks.HandlerMocks
-import com.m3.octoparts.model.config.HttpPartConfig
+import scala.collection.SortedSet
 import scala.concurrent.Future
-import com.m3.octoparts.aggregator.PartRequestInfo
 
 class PartRequestServiceSpec
     extends FunSpec
@@ -27,7 +27,7 @@ class PartRequestServiceSpec
   implicit val emptySpan = new Span()
   val repository = mock[ConfigsRepository]
   val config = mock[HttpPartConfig]
-  doReturn(Set.empty).when(config).parameters
+  doReturn(SortedSet.empty[PartParam]).when(config).parameters
   doReturn(None).when(config).deprecatedInFavourOf
   doReturn("123").when(config).partId
 

--- a/test/com/m3/octoparts/aggregator/service/RequestParamSupportSpec.scala
+++ b/test/com/m3/octoparts/aggregator/service/RequestParamSupportSpec.scala
@@ -7,6 +7,8 @@ import com.m3.octoparts.model.config._
 import org.joda.time.DateTime.now
 import org.scalatest.{ FunSpec, Matchers }
 
+import scala.collection.SortedSet
+
 class RequestParamSupportSpec extends FunSpec with Matchers with RequestParamSupport {
 
   describe("#combineParams") {
@@ -15,7 +17,7 @@ class RequestParamSupportSpec extends FunSpec with Matchers with RequestParamSup
       val pathParam2 = PartParam(required = true, versioned = false, paramType = Query, outputName = "requestUrl", updatedAt = now, createdAt = now)
       val reqMeta = RequestMeta("leId", userAgent = Some("leAgent"), requestUrl = Some("http://localhost"))
       val partReq = PartRequest("partId", params = Seq(PartRequestParam("requestUrl", "uzer")))
-      val registeredParams = Set(pathParam1, pathParam2)
+      val registeredParams = SortedSet(pathParam1, pathParam2)
       val expected = Map(
         ShortPartParam(pathParam1) -> Seq("http://localhost"),
         ShortPartParam(pathParam2) -> Seq("uzer")
@@ -23,7 +25,7 @@ class RequestParamSupportSpec extends FunSpec with Matchers with RequestParamSup
       combineParams(registeredParams, PartRequestInfo(reqMeta, partReq)) should equal(expected)
     }
     it("should keep parameter order, and not care about duplicate values") {
-      val registeredParams = Set(
+      val registeredParams = SortedSet(
         PartParam(required = false, versioned = false, paramType = Query, outputName = "p1", updatedAt = now, createdAt = now)
       )
       val reqMeta = RequestMeta("id")

--- a/test/com/m3/octoparts/cache/directive/CacheDirectiveGeneratorSpec.scala
+++ b/test/com/m3/octoparts/cache/directive/CacheDirectiveGeneratorSpec.scala
@@ -12,7 +12,7 @@ class CacheDirectiveGeneratorSpec extends FunSpec with Matchers with ConfigDataM
   val cacheDirectiveGenerator: CacheDirectiveGenerator = CacheDirectiveGenerator
 
   it("should make the most simple cache directive") {
-    val cacheConfig = CacheConfig(None, Nil)
+    val cacheConfig = CacheConfig(ttl = None, versionedParams = Nil)
     val cacheDirective = cacheDirectiveGenerator.generateDirective("", Map.empty, cacheConfig)
     cacheDirective.versionedParamKeys should be('empty)
     cacheDirective.ttl should be(None)
@@ -21,7 +21,7 @@ class CacheDirectiveGeneratorSpec extends FunSpec with Matchers with ConfigDataM
   it("should forward the part id, ttl and partRequestArgs in the cache directive") {
     val partId = "some part id"
     val ttl = FiniteDuration(5, TimeUnit.MINUTES)
-    val cacheConfig = CacheConfig(Some(ttl), Nil)
+    val cacheConfig = CacheConfig(Some(ttl), versionedParams = Nil)
     val partRequestArgs = Map(ShortPartParam("some key", ParamType.Query) -> Seq("some value"))
     val cacheDirective = cacheDirectiveGenerator.generateDirective(partId, partRequestArgs, cacheConfig)
     cacheDirective.versionedParamKeys should be('empty)

--- a/test/com/m3/octoparts/http/BlockingHttpRetrieveSpec.scala
+++ b/test/com/m3/octoparts/http/BlockingHttpRetrieveSpec.scala
@@ -13,11 +13,10 @@ class BlockingHttpRetrieveSpec extends FunSpec with Matchers with ScalaFutures {
     trait HttpRetrieveBodyContext {
       def httpMethod: HttpMethod
       def uriForCommand: URI = new URI("http://beachape.com")
-      def headersForCommand: Seq[(String, String)] = Seq.empty
       def command = new BlockingHttpRetrieve with MockHttpClientComponent {
         val method = httpMethod
         override val maybeBody = Some("thing")
-        override val headers = headersForCommand
+        override val headers = Nil
         val uri = uriForCommand
       }
     }

--- a/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
+++ b/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 import com.m3.octoparts.model.HttpMethod
 import com.m3.octoparts.model.config.json.AlertMailSettings
 import org.apache.commons.lang3.SerializationUtils
+import scala.collection.SortedSet
 import scala.concurrent.duration._
 import com.m3.octoparts.support.mocks.ConfigDataMocks
 import scala.language.postfixOps
@@ -23,8 +24,8 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
     it("should not throw when given a config with a HystrixConfig") {
       val jsonModel = HttpPartConfig.toJsonModel(mockHttpPartConfig.copy(
         hystrixConfig = Some(mockHystrixConfig),
-        additionalValidStatuses = Set(302),
-        cacheGroups = Set(mockCacheGroup)
+        additionalValidStatuses = SortedSet(302),
+        cacheGroups = SortedSet(mockCacheGroup)
       ))
       val expectedModel = json.HttpPartConfig(
         partId = "something",
@@ -40,7 +41,7 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
             queueSize = 256),
           commandKey = "command",
           commandGroupKey = "GroupKey",
-          false),
+          localContentsAsFallback = false),
         additionalValidStatuses = Set(302),
         httpPoolSize = 5,
         httpConnectionTimeout = 1.second,
@@ -51,6 +52,7 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
           json.PartParam(
             required = true,
             versioned = false,
+            description = None,
             paramType = ParamType.Header,
             outputName = "userId",
             inputNameOverride = None,
@@ -78,8 +80,8 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
     it("should serialise and deserialise without problems") {
       val original = mockHttpPartConfig.copy(
         hystrixConfig = Some(mockHystrixConfig),
-        additionalValidStatuses = Set(302),
-        cacheGroups = Set(mockCacheGroup)
+        additionalValidStatuses = SortedSet(302),
+        cacheGroups = SortedSet(mockCacheGroup)
       )
       val serialised = SerializationUtils.serialize(original)
       val deserialised = SerializationUtils.deserialize[HttpPartConfig](serialised)

--- a/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
+++ b/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
@@ -10,6 +10,7 @@ import org.joda.time.DateTime
 import org.scalatest.{ Matchers, fixture }
 import scalikejdbc.DBSession
 
+import scala.collection.SortedSet
 import scala.concurrent.duration._
 
 class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Matchers with ConfigDataMocks {
@@ -28,11 +29,12 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
   val httpPartConfigMapWithDeprecation = httpPartConfigMap :+ ('deprecatedInFavourOf -> Some("theNewHotness"))
 
   // ---- Helper functions ----
-  private def createCacheGroup(howMany: Int = 1)(implicit session: DBSession): Seq[CacheGroup] = {
-    for (i <- 0 until howMany) yield {
+  private def createCacheGroup(howMany: Int = 1)(implicit session: DBSession): SortedSet[CacheGroup] = {
+    val cacheGroups = for (i <- 0 until howMany) yield {
       val id = CacheGroupRepository.createWithAttributes('name -> s"myLittleGroup $i")
       CacheGroupRepository.findById(id).get
     }
+    cacheGroups.to[SortedSet]
   }
 
   private def createPartConfig(implicit session: DBSession): HttpPartConfig = {
@@ -98,19 +100,19 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
          */
         it("should allow me retrieve the PartParam and get back the CacheGroups") { implicit session =>
           val cacheGroups = createCacheGroup(3)
-          val partParam = mockPartParam.copy(id = None, cacheGroups = cacheGroups.toSet)
-          val partId = HttpPartConfigRepository.save(mockHttpPartConfig.copy(parameters = Set(partParam)))
+          val partParam = mockPartParam.copy(id = None, cacheGroups = cacheGroups)
+          val partId = HttpPartConfigRepository.save(mockHttpPartConfig.copy(parameters = SortedSet(partParam)))
           val partParamCacheGroupIdsRetrieved = for {
             param <- PartParamRepository.findByPartId(partId)
-            cacheGroup <- param.cacheGroups.toSeq
+            cacheGroup <- param.cacheGroups
           } yield cacheGroup.id
           partParamCacheGroupIdsRetrieved should be(cacheGroups.map(_.id))
         }
 
         it("should add the PartParam to the list of partParams on the CacheGroups") { implicit session =>
           val cacheGroups = createCacheGroup(3)
-          val partParam = mockPartParam.copy(id = None, cacheGroups = cacheGroups.toSet)
-          HttpPartConfigRepository.save(mockHttpPartConfig.copy(parameters = Set(partParam)))
+          val partParam = mockPartParam.copy(id = None, cacheGroups = cacheGroups)
+          HttpPartConfigRepository.save(mockHttpPartConfig.copy(parameters = SortedSet(partParam)))
           val retrievedCacheGroups = cacheGroups.map(cG => CacheGroupRepository.withChildren.findById(cG.id.get).get)
           retrievedCacheGroups.foreach(_.partParams.map(_.outputName) should contain(partParam.outputName))
         }
@@ -122,8 +124,8 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
         it("should allow me retrieve the HttpPartConfig and get back the CacheGroup within each PartParam") { implicit session =>
           val cacheGroups = createCacheGroup(3)
           val part = createPartConfig
-          val partParam = mockPartParam.copy(id = None, outputName = "param1", cacheGroups = cacheGroups.toSet, httpPartConfigId = part.id)
-          HttpPartConfigRepository.save(part.copy(parameters = Set(partParam)))
+          val partParam = mockPartParam.copy(id = None, outputName = "param1", cacheGroups = cacheGroups, httpPartConfigId = part.id)
+          HttpPartConfigRepository.save(part.copy(parameters = SortedSet(partParam)))
           val partParamCacheGroupIdsRetrieved = for {
             param <- PartParamRepository.findByPartId(part.id.get)
             cacheGroup <- param.cacheGroups
@@ -134,8 +136,8 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
         it("should add the PartParam to the list of partParams on the CacheGroup") { implicit session =>
           val cacheGroups = createCacheGroup(3)
           val part = createPartConfig
-          val partParam = mockPartParam.copy(id = None, outputName = "param2", cacheGroups = cacheGroups.toSet, httpPartConfigId = part.id)
-          HttpPartConfigRepository.save(part.copy(parameters = Set(partParam)))
+          val partParam = mockPartParam.copy(id = None, outputName = "param2", cacheGroups = cacheGroups, httpPartConfigId = part.id)
+          HttpPartConfigRepository.save(part.copy(parameters = SortedSet(partParam)))
           val retrievedCacheGroups = cacheGroups.map(cG => CacheGroupRepository.withChildren.findById(cG.id.get).get)
           retrievedCacheGroups.foreach(_.partParams.map(_.outputName) should contain(partParam.outputName))
         }
@@ -193,7 +195,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
 
   describe(".save") {
 
-    lazy val parameters = Seq(
+    lazy val parameters = SortedSet(
       PartParam(required = true, versioned = false, paramType = ParamType.Cookie, outputName = "myCookie", createdAt = DateTime.now, updatedAt = DateTime.now),
       PartParam(required = false, versioned = false, paramType = ParamType.Header, outputName = "myHeader", createdAt = DateTime.now, updatedAt = DateTime.now)
     )
@@ -224,12 +226,12 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
     def compare(expected: HttpPartConfig, observed: HttpPartConfig) = {
       val observedHystrixConfig = observed.hystrixConfigItem
       val observedThreadPoolConfig = observedHystrixConfig.threadPoolConfigItem
-      val observedConfigParams = observed.parameters.toSeq.sortWith(_.outputName < _.outputName)
+      val observedConfigParams = observed.parameters
 
       val expectedHystrixConfig = expected.hystrixConfigItem
 
       for {
-        (observed, expected) <- observedConfigParams.sortBy(_.inputName).zip(expected.parameters.toSeq.sortBy(_.inputName))
+        (observed, expected) <- observedConfigParams.zip(expected.parameters)
       } {
         observed.required should be(expected.required)
         observed.paramType should be(expected.paramType)
@@ -267,7 +269,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
             httpConnectionTimeout = 1.second,
             httpSocketTimeout = 5.seconds,
             httpDefaultEncoding = Charset.forName(StandardCharsets.US_ASCII.name),
-            parameters = parameters.toSet,
+            parameters = parameters,
             hystrixConfig = Some(insertedHystrixConfig),
             cacheTtl = Some(30.seconds),
             alertMailsEnabled = true,
@@ -302,7 +304,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
           httpConnectionTimeout = 1.second,
           httpSocketTimeout = 5.seconds,
           httpDefaultEncoding = Charset.forName(StandardCharsets.US_ASCII.name),
-          parameters = parameters.toSet,
+          parameters = parameters,
           hystrixConfig = Some(insertedHystrixConfig),
           cacheTtl = Some(10.minutes),
           alertMailsEnabled = true,
@@ -364,7 +366,7 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
 
       it("should allow me retrieve the HttpPartConfig and get back the CacheGroup") { implicit session =>
         val cacheGroups = createCacheGroup(3)
-        val partId = HttpPartConfigRepository.save(mockHttpPartConfig.copy(cacheGroups = cacheGroups.toSet))
+        val partId = HttpPartConfigRepository.save(mockHttpPartConfig.copy(cacheGroups = cacheGroups))
         val retrievedPart = HttpPartConfigRepository.findById(partId).get
         /*
          $1 billion question: Why does the above (using .byDefault) work, but the below, using .includes
@@ -376,12 +378,12 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
            HttpPartConfig.cacheGroupsRef, HttpPartConfig.hystrixConfigRef, HttpPartConfig.paramsRef
          ).findById(partId).get
          */
-        retrievedPart.cacheGroups.map(_.id) should be(cacheGroups.map(_.id).toSet)
+        retrievedPart.cacheGroups.map(_.id) should be(cacheGroups.map(_.id))
       }
 
       it("should add the HttpPartConfig to the list of httpPartConfigs on the CacheGroup") { implicit session =>
         val cacheGroups = createCacheGroup(2)
-        val partId = HttpPartConfigRepository.save(mockHttpPartConfig.copy(cacheGroups = cacheGroups.toSet))
+        val partId = HttpPartConfigRepository.save(mockHttpPartConfig.copy(cacheGroups = cacheGroups))
         val retrievedCacheGroups = cacheGroups.map(cG => CacheGroupRepository.withChildren.findById(cG.id.get).get)
         retrievedCacheGroups.foreach(_.httpPartConfigs.map(_.id) should contain(Some(partId)))
       }
@@ -393,15 +395,15 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
       it("should allow me retrieve the HttpPartConfig and get back the CacheGroup") { implicit session =>
         val cacheGroups = createCacheGroup(3)
         val part = createPartConfig
-        HttpPartConfigRepository.save(part.copy(cacheGroups = cacheGroups.toSet))
+        HttpPartConfigRepository.save(part.copy(cacheGroups = cacheGroups))
         val retrievedPart = HttpPartConfigRepository.findById(part.id.get)
-        retrievedPart.get.cacheGroups.map(_.id) should be(cacheGroups.map(_.id).toSet)
+        retrievedPart.get.cacheGroups.map(_.id) should be(cacheGroups.map(_.id))
       }
 
       it("should add the HttpPartConfig to the list of httpPartConfigs on the CacheGroup") { implicit session =>
         val cacheGroups = createCacheGroup(3)
         val part = createPartConfig
-        HttpPartConfigRepository.save(part.copy(cacheGroups = cacheGroups.toSet))
+        HttpPartConfigRepository.save(part.copy(cacheGroups = cacheGroups))
         val retrievedCacheGroups = cacheGroups.map(cG => CacheGroupRepository.withChildren.findById(cG.id.get).get)
         retrievedCacheGroups.foreach(_.httpPartConfigs.map(_.id) should contain(Some(part.id.get)))
       }

--- a/test/com/m3/octoparts/support/db/RequiresDB.scala
+++ b/test/com/m3/octoparts/support/db/RequiresDB.scala
@@ -21,28 +21,41 @@ import scala.util.control.NonFatal
 trait RequiresDB extends Suite with OneAppPerSuite {
 
   lazy val flyway = {
-    val poolName = ConnectionPool.DEFAULT_NAME.name
-    val pool = ConnectionPool.get(Symbol(poolName))
     val flyway = new Flyway
     flyway.setCallbacks(new FlywayCallback {
-      def beforeInit(conn: Connection) = { conn.setReadOnly(false) }
-      def beforeRepair(conn: Connection) = { conn.setReadOnly(false) }
-      def beforeValidate(conn: Connection) = { conn.setReadOnly(false) }
-      def beforeInfo(conn: Connection) = { conn.setReadOnly(false) }
-      def beforeClean(conn: Connection) = { conn.setReadOnly(false) }
-      def beforeMigrate(conn: Connection) = { conn.setReadOnly(false) }
-      def beforeBaseline(conn: Connection) = { conn.setReadOnly(false) }
+      def beforeInit(conn: Connection) = conn.setReadOnly(false)
+
+      def beforeRepair(conn: Connection) = conn.setReadOnly(false)
+
+      def beforeValidate(conn: Connection) = conn.setReadOnly(false)
+
+      def beforeInfo(conn: Connection) = conn.setReadOnly(false)
+
+      def beforeClean(conn: Connection) = conn.setReadOnly(false)
+
+      def beforeMigrate(conn: Connection) = conn.setReadOnly(false)
+
+      def beforeBaseline(conn: Connection) = conn.setReadOnly(false)
+
+      def beforeEachMigrate(conn: Connection, p2: MigrationInfo) = conn.setReadOnly(false)
+
       def afterInfo(conn: Connection) = {}
+
       def afterInit(conn: Connection) = {}
+
       def afterRepair(conn: Connection) = {}
+
       def afterValidate(conn: Connection) = {}
-      def beforeEachMigrate(conn: Connection, p2: MigrationInfo) = {}
+
       def afterEachMigrate(conn: Connection, p2: MigrationInfo) = {}
+
       def afterMigrate(conn: Connection) = {}
+
       def afterClean(conn: Connection) = {}
+
       def afterBaseline(conn: Connection) = {}
     })
-    flyway.setDataSource(pool.dataSource)
+    flyway.setDataSource(ConnectionPool().dataSource)
     flyway.setPlaceholderPrefix("$flyway{")
     flyway
   }

--- a/test/com/m3/octoparts/support/mocks/ConfigDataMocks.scala
+++ b/test/com/m3/octoparts/support/mocks/ConfigDataMocks.scala
@@ -8,6 +8,7 @@ import com.m3.octoparts.model.config.ParamType._
 import com.m3.octoparts.model.config._
 import org.joda.time.DateTime
 
+import scala.collection.SortedSet
 import scala.concurrent.duration._
 
 /**
@@ -38,7 +39,7 @@ trait ConfigDataMocks {
     httpSocketTimeout = 5.seconds,
     httpDefaultEncoding = Charset.forName(StandardCharsets.US_ASCII.name),
     httpProxy = Some("localhost:666"),
-    parameters = Set(mockPartParam),
+    parameters = SortedSet(mockPartParam),
     cacheTtl = Some(60.seconds),
     alertMailsEnabled = true,
     alertAbsoluteThreshold = Some(1000),

--- a/test/com/m3/octoparts/support/mocks/MockConfigRepository.scala
+++ b/test/com/m3/octoparts/support/mocks/MockConfigRepository.scala
@@ -5,6 +5,7 @@ import com.m3.octoparts.repository.config.ConfigMapper
 import com.m3.octoparts.repository.{ ConfigsRepository, MutableConfigsRepository }
 import com.twitter.zipkin.gen.Span
 
+import scala.collection.SortedSet
 import scala.concurrent.Future
 
 /**
@@ -14,19 +15,19 @@ trait MockConfigRepository extends ConfigsRepository with ConfigDataMocks {
 
   def findConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Option[HttpPartConfig]] = Future.successful(Some(mockHttpPartConfig))
 
-  def findAllConfigs()(implicit parentSpan: Span): Future[Seq[HttpPartConfig]] = Future.successful(Seq(mockHttpPartConfig))
+  def findAllConfigs()(implicit parentSpan: Span): Future[SortedSet[HttpPartConfig]] = Future.successful(SortedSet(mockHttpPartConfig))
 
   def findThreadPoolConfigById(id: Long)(implicit parentSpan: Span): Future[Option[ThreadPoolConfig]] = Future.successful(Some(mockThreadConfig))
 
-  def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[Seq[ThreadPoolConfig]] = Future.successful(Seq(mockThreadConfig))
+  def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[SortedSet[ThreadPoolConfig]] = Future.successful(SortedSet(mockThreadConfig))
 
-  def findAllCacheGroups()(implicit parentSpan: Span): Future[Seq[CacheGroup]] = Future.successful(Seq(mockCacheGroup))
+  def findAllCacheGroups()(implicit parentSpan: Span): Future[SortedSet[CacheGroup]] = Future.successful(SortedSet(mockCacheGroup))
 
   def findCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Option[CacheGroup]] = Future.successful(Some(mockCacheGroup.copy(name = name)))
 
   def findParamById(id: Long)(implicit parentSpan: Span): Future[Option[PartParam]] = Future.successful(Some(mockPartParam.copy(id = Some(123))))
 
-  def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span): Future[Seq[CacheGroup]] = Future.successful(Seq(mockCacheGroup))
+  def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span): Future[SortedSet[CacheGroup]] = Future.successful(SortedSet(mockCacheGroup))
 }
 
 /**
@@ -46,6 +47,6 @@ trait MockMutableRepository extends MockConfigRepository with MutableConfigsRepo
 
   def save[A <: ConfigModel[A]: ConfigMapper](obj: A)(implicit parentSpan: Span): Future[Long] = Future.successful(123)
 
-  def importConfigs(configs: Seq[json.HttpPartConfig])(implicit parentSpan: Span) = Future.successful(Seq.empty)
+  def importConfigs(configs: Seq[json.HttpPartConfig])(implicit parentSpan: Span) = Future.successful(Nil)
 
 }

--- a/test/controllers/AdminControllerSpec.scala
+++ b/test/controllers/AdminControllerSpec.scala
@@ -30,6 +30,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.mvc.Result
 
+import scala.collection.SortedSet
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -140,7 +141,7 @@ class AdminControllerSpec extends FunSpec
   it("should show a list of parts") {
     val repository = mock[MutableConfigsRepository]
     val adminController = new AdminController(cacheOps = DummyCacheOps, repository = repository)
-    doReturn(Future.successful(Seq(part.copy(uriToInterpolate = "http://www.example.com", owner = "aName")))).when(repository).findAllConfigs()
+    doReturn(Future.successful(SortedSet(part.copy(uriToInterpolate = "http://www.example.com", owner = "aName")))).when(repository).findAllConfigs()
 
     val listParts = adminController.listParts(FakeRequest())
     contentAsString(listParts) should include("http://www.example.com")
@@ -151,10 +152,10 @@ class AdminControllerSpec extends FunSpec
     val repository = mock[MutableConfigsRepository]
     val adminController = new AdminController(cacheOps = DummyCacheOps, repository = repository)
 
-    doReturn(Future.successful(Seq(part))).when(repository).findAllConfigs()
+    doReturn(Future.successful(SortedSet(part))).when(repository).findAllConfigs()
     doReturn(Future.successful(Some(part))).when(repository).findConfigByPartId(part.partId)
-    doReturn(Future.successful(Seq(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()
-    doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroups()
+    doReturn(Future.successful(SortedSet(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()
+    doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroups()
 
     val result = adminController.newPart.apply(FakeRequest())
     status(result) should equal(OK)
@@ -165,10 +166,10 @@ class AdminControllerSpec extends FunSpec
     val repository = mock[MutableConfigsRepository]
     val adminController = new AdminController(cacheOps = DummyCacheOps, repository = repository)
 
-    doReturn(Future.successful(Seq(part))).when(repository).findAllConfigs()
+    doReturn(Future.successful(SortedSet(part))).when(repository).findAllConfigs()
     doReturn(Future.successful(Some(part))).when(repository).findConfigByPartId(part.partId)
-    doReturn(Future.successful(Seq(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()
-    doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroups()
+    doReturn(Future.successful(SortedSet(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()
+    doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroups()
 
     val result = adminController.editPart(part.partId).apply(FakeRequest())
     status(result) should equal(OK)
@@ -179,9 +180,9 @@ class AdminControllerSpec extends FunSpec
     val repository = mock[MutableConfigsRepository]
     val adminController = new AdminController(cacheOps = DummyCacheOps, repository = repository)
     doReturn(Future.successful(124L)).when(repository).save(anyObject[HttpPartConfig]())(anyObject[ConfigMapper[HttpPartConfig]], anyObject[Span])
-    doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
-    doReturn(Future.successful(Seq(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()
-    doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroups()
+    doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
+    doReturn(Future.successful(SortedSet(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()
+    doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroups()
 
     val result = adminController.createPart.apply(FakeRequest().withFormUrlEncodedBody(validPartEditFormParams: _*))
     whenReady(result) { r =>
@@ -190,7 +191,7 @@ class AdminControllerSpec extends FunSpec
 
       val newCiCaptor = ArgumentCaptor.forClass(classOf[HttpPartConfig])
       verify(repository).save(newCiCaptor.capture())(anyObject[ConfigMapper[HttpPartConfig]], anyObject[Span])
-      verify(repository).findAllCacheGroupsByName(Seq.empty: _*)
+      verify(repository).findAllCacheGroupsByName(Nil: _*)
       newCiCaptor.getValue.uriToInterpolate should be("http://www.example2.com")
     }
   }
@@ -205,11 +206,11 @@ class AdminControllerSpec extends FunSpec
       doReturn(Future.successful(())).when(cacheOps).increasePartVersion(anyString())(anyObject[Span])
       doReturn(Future.successful(Some(part2))).when(repository).findConfigByPartId(mockitoEq(part.partId))(anyObject[Span])
       doReturn(Future.successful(1)).when(repository).deleteConfigByPartId(mockitoEq(part.partId))(anyObject[Span])
-      doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
+      doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
       doReturn(Future.successful(Some(mockPartParam))).when(repository).findParamById(anyLong())(anyObject[Span])
-      doReturn(Future.successful(Seq(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()(anyObject[Span])
-      doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroups()(anyObject[Span])
-      doReturn(Future.successful(Seq(part2))).when(repository).findAllConfigs()(anyObject[Span])
+      doReturn(Future.successful(SortedSet(mockThreadConfig))).when(repository).findAllThreadPoolConfigs()(anyObject[Span])
+      doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroups()(anyObject[Span])
+      doReturn(Future.successful(SortedSet(part2))).when(repository).findAllConfigs()(anyObject[Span])
       (adminController, cacheOps, repository, part2)
     }
 
@@ -354,13 +355,13 @@ class AdminControllerSpec extends FunSpec
       it("should copy the part and show the edit form for the newly created part") {
         val repository = mock[MutableConfigsRepository]
         val adminController = new AdminController(cacheOps = DummyCacheOps, repository = repository)
-        doReturn(Future.successful(Seq(part))).when(repository).findAllConfigs()(anyObject[Span])
+        doReturn(Future.successful(SortedSet(part))).when(repository).findAllConfigs()(anyObject[Span])
         doReturn(Future.successful(Some(part))).when(repository).findConfigByPartId(mockitoEq(part.partId))(anyObject[Span])
         doReturn(Future.successful(124L)).when(repository).save(anyObject[HttpPartConfig]())(anyObject[ConfigMapper[HttpPartConfig]], anyObject[Span])
 
         val result = adminController.copyPart(part.partId).apply(FakeRequest())
         status(result) should be(FOUND)
-        val expectedNewPartId = part.partId + "_"
+        val expectedNewPartId = s"${part.partId}_"
         redirectLocation(result).get should include(routes.AdminController.editPart(expectedNewPartId).url)
       }
     }
@@ -404,8 +405,8 @@ class AdminControllerSpec extends FunSpec
           val newCiCaptor = ArgumentCaptor.forClass(classOf[PartParam])
           verify(repository).save(newCiCaptor.capture())(anyObject[ConfigMapper[PartParam]], anyObject[Span])
 
-          newCiCaptor.getValue.inputName should be(existingParam.inputName + "_")
-          newCiCaptor.getValue.outputName should be(existingParam.outputName + "_")
+          newCiCaptor.getValue.inputName should be(s"${existingParam.inputName}_")
+          newCiCaptor.getValue.outputName should be(s"${existingParam.outputName}_")
           newCiCaptor.getValue.paramType should be(existingParam.paramType)
         }
       }
@@ -439,7 +440,7 @@ class AdminControllerSpec extends FunSpec
 
     doReturn(Future.successful(Some(part))).when(repository).findConfigByPartId(mockitoEq(part.partId))(anyObject[Span])
     doReturn(Future.successful(37L)).when(repository).save(anyObject[PartParam]())(anyObject[ConfigMapper[PartParam]], anyObject[Span])
-    doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
+    doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
 
     val createParam = adminController.createParam(part.partId)(
       FakeRequest().withFormUrlEncodedBody("outputName" -> "someName", "paramType" -> "cookie", "required" -> "true")
@@ -451,7 +452,7 @@ class AdminControllerSpec extends FunSpec
       verify(repository).findConfigByPartId(part.partId)
       val newCiCaptor = ArgumentCaptor.forClass(classOf[PartParam])
       verify(repository).save(newCiCaptor.capture())(anyObject[ConfigMapper[PartParam]], anyObject[Span])
-      verify(repository).findAllCacheGroupsByName(Seq.empty: _*)
+      verify(repository).findAllCacheGroupsByName(Nil: _*)
       verify(cacheOps, Mockito.timeout(1000)).increasePartVersion(part.partId)
 
       newCiCaptor.getValue.outputName should be("someName")
@@ -468,7 +469,7 @@ class AdminControllerSpec extends FunSpec
     doReturn(Future.successful(Some(part))).when(repository).findConfigByPartId(part.partId)
     doReturn(Future.successful(37L)).when(repository).save(anyObject[PartParam]())(anyObject[ConfigMapper[PartParam]], anyObject[Span])
     doReturn(Future.successful(Some(mockPartParam))).when(repository).findParamById(mockitoEq(mockPartParam.id.get))(anyObject[Span])
-    doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
+    doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
 
     val updateParam = adminController.updateParam(part.partId, mockPartParam.id.get)(
       FakeRequest().withFormUrlEncodedBody("outputName" -> "newName", "paramType" -> "body", "versioned" -> "true")
@@ -480,7 +481,7 @@ class AdminControllerSpec extends FunSpec
       verify(repository).findConfigByPartId(part.partId)
       val newCiCaptor = ArgumentCaptor.forClass(classOf[PartParam])
       verify(repository).save(newCiCaptor.capture())(anyObject[ConfigMapper[PartParam]], anyObject[Span])
-      verify(repository).findAllCacheGroupsByName(Seq.empty: _*)
+      verify(repository).findAllCacheGroupsByName(Nil: _*)
       verify(cacheOps, Mockito.timeout(1000)).increasePartVersion(part.partId)
 
       newCiCaptor.getValue.outputName should be("newName")
@@ -496,7 +497,7 @@ class AdminControllerSpec extends FunSpec
     when(repository.deletePartParamById(anyLong())(anyObject[Span])).thenReturn(Future.successful(1))
     doReturn(Future.successful(Some(part))).when(repository).findConfigByPartId(part.partId)
     doReturn(Future.successful(Some(mockPartParam))).when(repository).findParamById(mockitoEq(mockPartParam.id.get))(anyObject[Span])
-    doReturn(Future.successful(Seq.empty)).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
+    doReturn(Future.successful(SortedSet.empty[CacheGroup])).when(repository).findAllCacheGroupsByName(anyVararg[String]())(anyObject[Span])
 
     val deleteParam = adminController.deleteParam(part.partId, mockPartParam.id.get)(FakeRequest())
     status(deleteParam) should equal(FOUND)

--- a/test/controllers/AdminFormsSpec.scala
+++ b/test/controllers/AdminFormsSpec.scala
@@ -5,6 +5,8 @@ import com.m3.octoparts.support.mocks.ConfigDataMocks
 import controllers.AdminForms._
 import org.scalatest.{ FunSpec, Matchers }
 
+import scala.collection.SortedSet
+
 class AdminFormsSpec extends FunSpec with Matchers with ConfigDataMocks {
 
   describe("PartData") {
@@ -45,7 +47,7 @@ class AdminFormsSpec extends FunSpec with Matchers with ConfigDataMocks {
 
     describe("#toNewHttpPartConfig") {
       it("should trim leading and trailing spaces from the partId") {
-        val partConfig = partDataWithTrimableName.toNewHttpPartConfig("chris", Set.empty[CacheGroup])
+        val partConfig = partDataWithTrimableName.toNewHttpPartConfig("chris", SortedSet.empty)
         partConfig.partId should be("~ wowzers ~")
       }
     }
@@ -53,7 +55,7 @@ class AdminFormsSpec extends FunSpec with Matchers with ConfigDataMocks {
     describe("#toUpdatedHttpPartConfig") {
       it("should trim leading and trailing spaces from the partId") {
         val originalPart = mockHttpPartConfig.copy(hystrixConfig = Some(mockHystrixConfig))
-        val updatedPart = partDataWithTrimableName.toUpdatedHttpPartConfig(originalPart, Set.empty[PartParam], Set.empty[CacheGroup])
+        val updatedPart = partDataWithTrimableName.toUpdatedHttpPartConfig(originalPart, SortedSet.empty)
         updatedPart.partId should be("~ wowzers ~")
       }
     }

--- a/test/controllers/CacheControllerSpec.scala
+++ b/test/controllers/CacheControllerSpec.scala
@@ -1,58 +1,46 @@
 package controllers
 
 import com.m3.octoparts.cache.CacheOps
+import com.m3.octoparts.cache.versioning.VersionedParamKey
+import com.m3.octoparts.model.config.CacheGroup
+import com.m3.octoparts.repository.ConfigsRepository
+import com.m3.octoparts.support.mocks.ConfigDataMocks
 import com.twitter.zipkin.gen.Span
+import org.mockito.Matchers.{ eq => mockitoEq, _ }
+import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ FlatSpec, Matchers }
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
+import scala.collection.SortedSet
 import scala.concurrent.Future
 import scala.language.postfixOps
 
-import com.m3.octoparts.support.mocks.{ MockConfigRepository, ConfigDataMocks }
-import com.m3.octoparts.model.config.{ PartParam, CacheGroup, HttpPartConfig }
-import org.scalatest.mock.MockitoSugar
-import org.mockito.Mockito._
-import org.mockito.Matchers._
-import com.m3.octoparts.cache.versioning.VersionedParamKey
 class CacheControllerSpec extends FlatSpec with Matchers with MockitoSugar with ConfigDataMocks with ScalaFutures {
-  implicit val emptySpan = new Span()
+  private implicit val emptySpan = new Span()
 
-  val futureUnit = Future.successful(())
-  val mockRepository = new MockConfigRepository {
-    val configNames = Seq("part1", "part2")
-    val paramIds = Seq(1, 2)
-    val cacheGroupKeyNames = Seq("group1")
-
-    override def findCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Option[CacheGroup]] = Future.successful(
-      if (cacheGroupKeyNames.contains(name))
-        Some(mockCacheGroup.copy(
-        id = Some(42),
-        httpPartConfigs = Seq(mockHttpPartConfig, mockHttpPartConfig.copy(partId = "another")),
-        partParams = Seq(mockPartParam, mockPartParam)
-      ))
-      else
-        None
+  private def partCacheGroup: CacheGroup = mockCacheGroup.copy(
+    name = "group1",
+    httpPartConfigs = SortedSet(mockHttpPartConfig, mockHttpPartConfig.copy(partId = "another"))
+  )
+  private def paramCacheGroup: CacheGroup = mockCacheGroup.copy(
+    name = "group2",
+    partParams = SortedSet(
+      mockPartParam.copy(httpPartConfig = Some(mockHttpPartConfig)),
+      mockPartParam.copy(outputName = "another param", httpPartConfig = Some(mockHttpPartConfig.copy(partId = "another")))
     )
-    override def findConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Option[HttpPartConfig]] = Future.successful {
-      if (configNames.contains(partId)) Some(mockHttpPartConfig.copy(id = Some(3), partId = partId)) else None
-    }
-    override def findParamById(id: Long)(implicit parentSpan: Span): Future[Option[PartParam]] = Future.successful {
-      Some(mockPartParam.copy(httpPartConfig = Some(mockHttpPartConfig)))
-    }
-    override def findAllConfigs()(implicit parentSpan: Span): Future[Seq[HttpPartConfig]] = Future.successful(configNames.map { key =>
-      mockHttpPartConfig.copy(id = Some(3), partId = key)
-    })
-  }
-  val mockCacheOps = mock[CacheOps]
-  val controller = new CacheController(mockCacheOps, mockRepository)
+  )
 
   it should "return 200 and call increasePartVersion with the partId when /invalidate/:partId is called" in {
-    doReturn(futureUnit).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
+    val mockCacheOps = mock[CacheOps](RETURNS_SMART_NULLS)
+    val mockRepository = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+    val controller = new CacheController(mockCacheOps, mockRepository)
+    doReturn(Future.successful(Unit)).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
     whenReady(controller.invalidatePart("part1").apply(FakeRequest())) { result =>
       verify(mockCacheOps).increasePartVersion("part1")
-      result.header.status should be(200)
+      result.header.status should be(OK)
     }
   }
 
@@ -60,53 +48,80 @@ class CacheControllerSpec extends FlatSpec with Matchers with MockitoSugar with 
     """
       |return 200 and call increaseParamVersion with the partId, param name, and param value when
       |/invalidate/:partId/:paramName/:paramValue is called""".stripMargin in {
-      doReturn(futureUnit).when(mockCacheOps).increaseParamVersion(anyObject[VersionedParamKey]())(anyObject[Span])
-      whenReady(controller.invalidatePartParam("part1", "paramName", "paramValue").apply(FakeRequest())) { result =>
+      val mockCacheOps = mock[CacheOps](RETURNS_SMART_NULLS)
+      val mockRepository = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+      val controller = new CacheController(mockCacheOps, mockRepository)
+      doReturn(Future.successful(Unit)).when(mockCacheOps).increaseParamVersion(anyObject[VersionedParamKey]())(anyObject[Span])
+      whenReady(controller.invalidatePartParam("part1", "paramName", "paramValue")(FakeRequest())) { result =>
         verify(mockCacheOps).increaseParamVersion(VersionedParamKey("part1", "paramName", "paramValue"))
-        result.header.status should be(200)
+        verifyNoMoreInteractions(mockCacheOps)
       }
     }
 
   it should "return 404 when /invalidate/cacheGroup/:cacheGroupName is called with a non existent cacheGroupName" in {
-    status(controller.invalidateCacheGroupParts("wutthewut").apply(FakeRequest())) should be(404)
+    val mockCacheOps = mock[CacheOps](RETURNS_SMART_NULLS)
+    val mockRepository = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+    val controller = new CacheController(mockCacheOps, mockRepository)
+    doReturn(Future.successful(None)).when(mockRepository).findCacheGroupByName(mockitoEq("wutthewut"))(anyObject[Span])
+    whenReady(controller.invalidateCacheGroupParts("wutthewut")(FakeRequest())) { result =>
+      result.header.status should be(NOT_FOUND)
+      verifyNoMoreInteractions(mockCacheOps)
+    }
   }
 
   it should "return 200 when /invalidate/cacheGroup/:cacheGroupName is called with an existing cacheGroupName" in {
-    doReturn(futureUnit).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
-    whenReady(controller.invalidateCacheGroupParts("group1").apply(FakeRequest())) { result =>
+    val mockCacheOps = mock[CacheOps](RETURNS_SMART_NULLS)
+    val mockRepository = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+    val controller = new CacheController(mockCacheOps, mockRepository)
+    doReturn(Future.successful(Some(partCacheGroup))).when(mockRepository).findCacheGroupByName(mockitoEq("group1"))(anyObject[Span])
+    doReturn(Future.successful(Unit)).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
+    whenReady(controller.invalidateCacheGroupParts("group1")(FakeRequest())) { result =>
       verify(mockCacheOps).increasePartVersion(mockHttpPartConfig.partId)
       verify(mockCacheOps).increasePartVersion("another")
-      result.header.status should be(200)
+      verifyNoMoreInteractions(mockCacheOps)
+      result.header.status should be(OK)
     }
   }
 
   it should "return 404 when /invalidate/cacheGroup/:cacheGroupName/params/:pvalue is called with a non existent cacheGroupName" in {
-    doReturn(futureUnit).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
-    status(controller.invalidateCacheGroupParam("wutthewut", "irrelevant").apply(FakeRequest())) should be(404)
+    val mockCacheOps = mock[CacheOps](RETURNS_SMART_NULLS)
+    val mockRepository = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+    val controller = new CacheController(mockCacheOps, mockRepository)
+    doReturn(Future.successful(None)).when(mockRepository).findCacheGroupByName(mockitoEq("wutthewut"))(anyObject[Span])
+    doReturn(Future.successful(Unit)).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
+    whenReady(controller.invalidateCacheGroupParam("wutthewut", "irrelevant")(FakeRequest())) { result =>
+      result.header.status should be(NOT_FOUND)
+      verifyNoMoreInteractions(mockCacheOps)
+    }
   }
 
   it should "return 500 along with a proper string describing the error when a cache invalidation fails" in {
-    doReturn(Future.failed(new IllegalArgumentException)).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
-    (1 until 50).foreach { _ =>
-      val result = controller.invalidateCacheGroupParts("group1").apply(FakeRequest())
-      status(result) should be(500)
-      contentAsString(result) should include("ERROR")
+    val mockCacheOps = mock[CacheOps](RETURNS_SMART_NULLS)
+    val mockRepository = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+    val controller = new CacheController(mockCacheOps, mockRepository)
+    doReturn(Future.successful(Some(partCacheGroup))).when(mockRepository).findCacheGroupByName(mockitoEq("group1"))(anyObject[Span])
+    doReturn(Future.failed(new IllegalArgumentException("within test"))).when(mockCacheOps).increasePartVersion(anyString())(anyObject[Span])
+    val fResult = controller.invalidateCacheGroupParts("group1")(FakeRequest())
+    whenReady(fResult) { result =>
+      result.header.status should be(INTERNAL_SERVER_ERROR)
+      contentAsString(fResult) should include("ERROR")
+      verify(mockCacheOps).increasePartVersion(mockHttpPartConfig.partId)
+      verify(mockCacheOps).increasePartVersion("another")
+      verifyNoMoreInteractions(mockCacheOps)
     }
   }
 
-  it should "return 200 and when /invalidate/cacheGroup/:cacheGroupName/params/:pvalue is called with an existing cacheGroupName" in {
-    doReturn(futureUnit).when(mockCacheOps).increaseParamVersion(anyObject[VersionedParamKey]())(anyObject[Span])
-    whenReady(controller.invalidateCacheGroupParam("group1", "12345").apply(FakeRequest())) { result =>
-      /*
-       * Even though the CacheGroup is mocked to have 2 different PartParams, the mock repository's
-       * findParamById query that re-retrieves each PartParam (in order to eager-load their parent
-       * HttpPartConfig) returns the same PartParam all the time, which causes the same arguments to
-       * be passed to increaseParamVersion
-      */
-      verify(mockCacheOps, times(2)).increaseParamVersion(VersionedParamKey(mockHttpPartConfig.partId, mockPartParam.outputName, "12345"))
-      result.header.status should be(200)
+  it should "return 200 when /invalidate/cacheGroup/:cacheGroupName/params/:pvalue is called with an existing cacheGroupName" in {
+    val mockCacheOps = mock[CacheOps](RETURNS_SMART_NULLS)
+    val mockRepository = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+    val controller = new CacheController(mockCacheOps, mockRepository)
+    doReturn(Future.successful(Some(paramCacheGroup))).when(mockRepository).findCacheGroupByName(mockitoEq("group2"))(anyObject[Span])
+    doReturn(Future.successful(Unit)).when(mockCacheOps).increaseParamVersion(anyObject[VersionedParamKey]())(anyObject[Span])
+    whenReady(controller.invalidateCacheGroupParam("group2", "12345").apply(FakeRequest())) { result =>
+      verify(mockCacheOps).increaseParamVersion(VersionedParamKey(mockHttpPartConfig.partId, mockPartParam.outputName, "12345"))
+      verify(mockCacheOps).increaseParamVersion(VersionedParamKey("another", "another param", "12345"))
+      verifyNoMoreInteractions(mockCacheOps)
+      result.header.status should be(OK)
     }
   }
-
 }
-

--- a/test/controllers/PartsControllerSpec.scala
+++ b/test/controllers/PartsControllerSpec.scala
@@ -18,6 +18,7 @@ import play.api.libs.json.{ JsSuccess, Json }
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
+import scala.collection.SortedSet
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -25,38 +26,38 @@ import scala.language.postfixOps
 class PartsControllerSpec extends FlatSpec with Matchers with MockitoSugar with ConfigDataMocks with OneAppPerSuite {
 
   import scala.concurrent.ExecutionContext.Implicits.global
-  implicit val emptySpan = new Span()
+  private implicit val emptySpan = new Span()
 
-  def createConfig(partId: String): HttpPartConfig = mockHttpPartConfig.copy(
+  private def createConfig(partId: String): HttpPartConfig = mockHttpPartConfig.copy(
     partId = partId,
     uriToInterpolate = "http://www.example.com/" + partId,
     hystrixConfig = Some(mockHystrixConfig)
   )
 
-  val configsRepository = new MockConfigRepository {
+  private val configsRepository = new MockConfigRepository {
     def keys = Seq("void", "error", "slow")
 
     override def findConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Option[HttpPartConfig]] = Future.successful {
       if (keys.contains(partId)) Some(createConfig(partId)) else None
     }
 
-    override def findAllConfigs()(implicit parentSpan: Span): Future[Seq[HttpPartConfig]] = Future.successful(keys.map(createConfig))
+    override def findAllConfigs()(implicit parentSpan: Span): Future[SortedSet[HttpPartConfig]] = Future.successful(keys.map(createConfig).to[SortedSet])
   }
-  val voidHandler = new Handler {
+  private val voidHandler = new Handler {
     val partId = "something"
 
     def process(pri: PartRequestInfo, args: HandlerArguments)(implicit parentSpan: Span) = Future.successful(PartResponse(partId, partId))
   }
-  val partsRequestService = new PartRequestService(configsRepository, new HttpHandlerFactory {
+  private val partsRequestService = new PartRequestService(configsRepository, new HttpHandlerFactory {
     implicit val zipkinService: ZipkinServiceLike = NoopZipkinService
     override def makeHandler(ci: HttpPartConfig) = ci.partId match {
       case "void" => voidHandler
       case _ => throw new RuntimeException
     }
   }, NoopZipkinService)
-  val partsService = new PartsService(partsRequestService)
+  private val partsService = new PartsService(partsRequestService)
 
-  val controller = new PartsController(partsService, configsRepository, 10 seconds, true, NoopZipkinService)
+  private val controller = new PartsController(partsService, configsRepository, 10 seconds, true, NoopZipkinService)
 
   it should "return 400 to an unknown json" in {
     val json = Json.parse("""{"json":"unknown"}""")

--- a/test/controllers/support/AuthorizationCheckSupportSpec.scala
+++ b/test/controllers/support/AuthorizationCheckSupportSpec.scala
@@ -1,6 +1,6 @@
 package controllers.support
 
-import com.m3.octoparts.auth.{ PrincipalSessionPersistence, OctopartsAuthPlugin, Principal }
+import com.m3.octoparts.auth.{ OctopartsAuthPlugin, PrincipalSessionPersistence }
 import org.scalatest.{ FlatSpec, Matchers }
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.mvc.Action
@@ -12,7 +12,6 @@ import scala.concurrent.Future
 
 class AuthorizationCheckSupportSpec extends FlatSpec with Matchers with OneAppPerSuite
     with AuthenticationCheckSupport with AuthorizationCheckSupport {
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   val authPlugin: Option[OctopartsAuthPlugin] = None
 

--- a/test/controllers/system/HealthcheckControllerSpec.scala
+++ b/test/controllers/system/HealthcheckControllerSpec.scala
@@ -6,8 +6,11 @@ import com.m3.octoparts.cache.RawCache
 import com.m3.octoparts.hystrix.HystrixHealthReporter
 import com.m3.octoparts.model.config.HttpPartConfig
 import com.m3.octoparts.repository.ConfigsRepository
+import com.m3.octoparts.support.mocks.ConfigDataMocks
 import com.twitter.zipkin.gen.Span
 import org.mockito.Mockito._
+import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls
+import org.mockito.stubbing.Answer
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfterEach, FlatSpec, Matchers }
 import org.scalatestplus.play.OneAppPerSuite
@@ -15,6 +18,7 @@ import play.api.libs.json.JsValue
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import shade.memcached.Codec
+import scala.collection.SortedSet
 import scala.concurrent.Future
 import org.mockito.Matchers._
 import org.mockito.Matchers.{ eq => mockitoEq }
@@ -25,22 +29,22 @@ class HealthcheckControllerSpec
     with MockitoSugar
     with BeforeAndAfterEach
     with JsonCheckSupport
-    with OneAppPerSuite {
+    with OneAppPerSuite
+    with ConfigDataMocks {
 
-  implicit val emptySpan = new Span()
-  val mockConfigs = Seq(mock[HttpPartConfig], mock[HttpPartConfig], mock[HttpPartConfig])
-  val configsRepo = mock[ConfigsRepository]
-  val hystrixHealthReporter = mock[HystrixHealthReporter]
-  val cache = mock[RawCache]
+  private implicit val emptySpan = new Span()
+  private val configsRepo = mock[ConfigsRepository](RETURNS_SMART_NULLS)
+  private val hystrixHealthReporter = mock[HystrixHealthReporter](RETURNS_SMART_NULLS)
+  private val cache = mock[RawCache](RETURNS_SMART_NULLS)
 
   override def beforeEach() {
     reset(configsRepo, hystrixHealthReporter, cache)
 
     // Return healthy-looking results by default
-    when(configsRepo.findAllConfigs()).thenReturn(Future.successful(mockConfigs))
-    when(hystrixHealthReporter.getCommandKeysWithOpenCircuitBreakers).thenReturn(Seq())
-    when(cache.get[String](mockitoEq("ping"))(anyObject[Codec[String]], anyObject[Span]))
-      .thenReturn(Future.successful(Some("pong")))
+    val mockConfigs = SortedSet(mockHttpPartConfig, mockHttpPartConfig.copy(partId = "another"), mockHttpPartConfig.copy(partId = "yet another"))
+    doReturn(Future.successful(mockConfigs)).when(configsRepo).findAllConfigs()(anyObject[Span])
+    when(hystrixHealthReporter.getCommandKeysWithOpenCircuitBreakers).thenReturn(Nil)
+    when(cache.get[String](mockitoEq("ping"))(anyObject[Codec[String]], anyObject[Span])).thenReturn(Future.successful(Some("pong")))
   }
 
   {
@@ -53,18 +57,18 @@ class HealthcheckControllerSpec
     it should "be GREEN if DB is healthy, there are no open circuits and Memcached is healthy" in {
       checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
         colour should be("GREEN")
-        dbOk should be(true)
-        hystrixOk should be(true)
-        cacheOk should be(true)
+        dbOk shouldBe true
+        hystrixOk shouldBe true
+        cacheOk shouldBe true
       }
     }
 
     it should "be YELLOW and show DB as not OK if there are no part configs" in {
-      when(configsRepo.findAllConfigs()(anyObject[Span])).thenReturn(Future.successful(Seq.empty))
+      when(configsRepo.findAllConfigs()(anyObject[Span])).thenReturn(Future.successful(SortedSet.empty[HttpPartConfig]))
 
       checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
         colour should be("YELLOW")
-        dbOk should be(false)
+        dbOk shouldBe false
       }
     }
 
@@ -73,7 +77,7 @@ class HealthcheckControllerSpec
 
       checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
         colour should be("YELLOW")
-        dbOk should be(false)
+        dbOk shouldBe false
         (json \ "statuses" \ "db" \ "message").as[String] should include("OH MY GOD!")
       }
     }
@@ -83,7 +87,7 @@ class HealthcheckControllerSpec
 
       checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
         colour should be("YELLOW")
-        hystrixOk should be(false)
+        hystrixOk shouldBe false
       }
     }
 
@@ -93,7 +97,7 @@ class HealthcheckControllerSpec
 
       checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
         colour should be("YELLOW")
-        cacheOk should be(false)
+        cacheOk shouldBe false
       }
     }
 
@@ -109,7 +113,7 @@ class HealthcheckControllerSpec
 
         checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
           colour should be("GREEN")
-          cacheOk should be(true)
+          cacheOk shouldBe true
         }
       }
 
@@ -120,7 +124,7 @@ class HealthcheckControllerSpec
 
         checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
           colour should be("YELLOW")
-          cacheOk should be(false)
+          cacheOk shouldBe false
         }
       }
     }


### PR DESCRIPTION
As a convenience, made all UI lists sorted consistently :
- part configs by part_id
- part parameters by output_name
- thread pools by key
- cache groups by name

To this purpose, the models now hold `Seq`s instead of `Set`s. This should not trigger an API change, but next client will not be binary compatible.

Also :
- fixed a runtime error when setting a local cache buffer with TTL = 0
- removed `SimpleHttpHandler.registeredParams` (unused)
