### PR TITLE
Use conservative URI encoding by default so Java URI doesn't blow up when being instantiated

### DIFF
--- a/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
@@ -10,6 +10,7 @@ import com.m3.octoparts.hystrix._
 import com.m3.octoparts.model.{ HttpMethod, PartResponse }
 import com.m3.octoparts.model.config._
 import com.netaporter.uri.Uri
+import com.netaporter.uri.config.UriConfig
 import com.netaporter.uri.dsl._
 import com.twitter.zipkin.gen.Span
 
@@ -85,7 +86,7 @@ trait HttpPartRequestHandler extends Handler {
     new BlockingHttpRetrieve {
       val httpClient = handler.httpClient
       def method = httpMethod
-      val uri = new URI(buildUri(hArgs))
+      val uri = new URI(buildUri(hArgs).toString(UriConfig.conservative))
       val maybeBody = hArgs.collectFirst {
         case (p, values) if p.paramType == ParamType.Body && values.nonEmpty => values.head
       }

--- a/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
+++ b/test/com/m3/octoparts/aggregator/handler/HttpPartRequestHandlerSpec.scala
@@ -117,6 +117,12 @@ class HttpPartRequestHandlerSpec extends FunSpec with Matchers with ScalaFutures
       headers should contain("X-OCTOPARTS-REQUEST-ID" -> "bande a part")
       headers should contain("X-OCTOPARTS-PARENT-REQUEST-ID" -> "hey man that's so meta")
     }
+    it("should be able to pass exotic query params") {
+      val hArgs = Map(
+        ShortPartParam("query1", Query) -> Seq("\"'&=")
+      )
+      handler.createBlockingHttpRetrieve(partRequestInfo, hArgs, None).uri.getQuery shouldBe "query1=\"'&="
+    }
   }
 
   describe("#collectHeaders") {


### PR DESCRIPTION
Meh.