### PR TITLE
Fixed bogus warning when saving a part config

### DIFF
--- a/app/views/part/edit.scala.html
+++ b/app/views/part/edit.scala.html
@@ -85,7 +85,7 @@
                     <div class="col-sm-5">
                         @helper.inputText(form("partId"),
                             'class -> "form-control validate[required]",
-                            Symbol("data-orig-value") -> form("partId").value)
+                            Symbol("data-orig-value") -> form("partId").value.getOrElse(""))
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
twirl collapses `Option[String]` ... most of the time