### PR TITLE
Change healthcheck API to report open circuits but return "GREEN" anyway #144

### DIFF
--- a/app/controllers/system/HealthcheckController.scala
+++ b/app/controllers/system/HealthcheckController.scala
@@ -45,7 +45,7 @@ class HealthcheckController(configsRepo: ConfigsRepository,
           "hystrix" -> hystrixStatus,
           "memcached" -> memcachedStatus
         )
-        val colour = calculateColour(statuses.values)
+        val colour = calculateColour(statuses.filterKeys(_ != "hystrix").values)
         val health = ServiceHealth(colour, statuses)
         logIfUnhealthy(health)
         health

--- a/test/controllers/system/HealthcheckControllerSpec.scala
+++ b/test/controllers/system/HealthcheckControllerSpec.scala
@@ -80,11 +80,12 @@ class HealthcheckControllerSpec
       }
     }
 
-    it should "be YELLOW and show Hystrix as not OK if there are any open Hystrix circuits" in {
+    it should "be GREEN and show Hystrix as not OK if there are any open Hystrix circuits" in {
       when(hystrixHealthReporter.getCommandKeysWithOpenCircuitBreakers).thenReturn(Seq("mrkun", "career"))
 
       checkJson(controller.healthcheck.apply(FakeRequest())) { implicit json =>
-        colour should be("YELLOW")
+        // https://github.com/m3dev/octoparts/pull/150
+        colour should be("GREEN")
         hystrixOk shouldBe false
       }
     }


### PR DESCRIPTION
refs #144  
I can't stand receiving noisy (and almost useless) mobile alerts anymore.. This pull request goes with the second suggestion by @mauhiz [here](https://github.com/m3dev/octoparts/issues/144#issue-63890829). 