### PR TITLE
Copy application.dev.conf from sample if it doesn't exist

### DIFF
--- a/vaygrant/provisioning/roles/global_env/tasks/main.yml
+++ b/vaygrant/provisioning/roles/global_env/tasks/main.yml
@@ -7,3 +7,14 @@
   file: >
     dest={{ octoparts_log_dir }} state=directory
     owner={{ app_user }} group={{ app_group }} mode=755
+
+- name: Check if conf file exists
+  stat: path=/parts/conf/application.dev.conf
+  register: app_conf_stat
+
+- name: Create conf file
+  command: cp /parts/conf/application.dev.conf.sample /parts/conf/application.dev.conf
+  when: not app_conf_stat.stat.exists
+
+- name: Set permissions on conf file
+  file: path=/parts/conf/application.dev.conf owner={{ app_user }} group={{ app_group }} mode=644


### PR DESCRIPTION
I wasn't sure where to put this since there's no role for octoparts so I put it in global. Also not sure if there's a way to copy a file from outside of ansible playbook paths and set the file permissions in the same command, so I split it up.

Addresses #158.