### PR TITLE
Vagrant Zipkin

### DIFF
--- a/vaygrant/Vagrantfile
+++ b/vaygrant/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # within the machine from a port on the host machine.
   config.vm.network :forwarded_port, guest: 9000, host: 9000 # For accessing octoparts
   config.vm.network :forwarded_port, guest: 8080, host: 8080 # For accessing hystrix-dashboard from host
+  config.vm.network :forwarded_port, guest: 8085, host: 8085 # For accessing zipkin-web from host
   config.vm.network :forwarded_port, guest: 8443, host: 8443
   config.vm.network :forwarded_port, guest: 5432, host: 5432 # PSQL
   config.vm.network :forwarded_port, guest: 11211, host: 11211 # Memcached

--- a/vaygrant/provisioning/dev_vm.yml
+++ b/vaygrant/provisioning/dev_vm.yml
@@ -8,6 +8,7 @@
     - disable_iptables # makes sense for dev vms only
     - yum_repos
     - { role: java, when: accept_oracle_licence == "yes" }
+    - { role: java7, when: accept_oracle_licence == "yes" }
     - { role: postgres, db_user: octoparts_app, db_name: octoparts, db_password: passw0rd }
     - { role: global_env, app_user: vagrant, app_group: vagrant, play_env: dev }
     - tomcat # Default variables for this role deploy the Hystrix dashboard ..

--- a/vaygrant/provisioning/dev_vm.yml
+++ b/vaygrant/provisioning/dev_vm.yml
@@ -15,3 +15,4 @@
     - td_agent
     - elasticsearch
     - kibana
+    - zipkin

--- a/vaygrant/provisioning/roles/global_env/templates/octoparts
+++ b/vaygrant/provisioning/roles/global_env/templates/octoparts
@@ -1,2 +1,4 @@
 export PLAY_ENV={{ play_env }}
 export OCTOPARTS_LOG_DIR={{ octoparts_log_dir }}
+export OCTOPARTS_ZIPKIN_HOST=localhost
+export OCTOPARTS_ZIPKIN_PORT=9410

--- a/vaygrant/provisioning/roles/global_env/templates/octoparts
+++ b/vaygrant/provisioning/roles/global_env/templates/octoparts
@@ -2,3 +2,4 @@ export PLAY_ENV={{ play_env }}
 export OCTOPARTS_LOG_DIR={{ octoparts_log_dir }}
 export OCTOPARTS_ZIPKIN_HOST=localhost
 export OCTOPARTS_ZIPKIN_PORT=9410
+export OCTOPARTS_ZIPKIN_SAMPLE_RATE=2.0

--- a/vaygrant/provisioning/roles/java7/defaults/main.yml
+++ b/vaygrant/provisioning/roles/java7/defaults/main.yml
@@ -1,0 +1,4 @@
+jdk7_version: '1.7.0_80'
+jdk7_pkg_version: '7'
+symlink_to: 'java7'
+src_base_dir: "/tmp"

--- a/vaygrant/provisioning/roles/java7/tasks/main.yml
+++ b/vaygrant/provisioning/roles/java7/tasks/main.yml
@@ -1,0 +1,31 @@
+- name: create /usr/java directory
+  file: path=/usr/java state=directory owner=root group=root mode=0755
+  tags: java7
+
+- name: check jdk7 package downloaded
+  command: test -f {{ src_base_dir }}/jdk-{{ jdk7_pkg_version }}-linux-x64.tar.gz
+  register: jdk7_downloaded
+  failed_when: jdk7_downloaded.rc not in [0, 1]
+  changed_when: False
+  tags: java7
+
+- name: download jdk7 package
+  command: >
+    wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.tar.gz" -O {{ src_base_dir }}/jdk-{{ jdk7_pkg_version }}-linux-x64.tar.gz
+  tags: java7
+  when: jdk7_downloaded.rc == 1
+
+- name: extract jdk7
+  command: >
+    tar -xf {{ src_base_dir }}/jdk-{{ jdk7_pkg_version }}-linux-x64.tar.gz
+    chdir=/usr/java
+    creates=/usr/java/jdk{{ jdk7_version }}
+  tags: java7
+
+- name: symlink to /usr/local
+  file: >
+    state=link
+    src=/usr/java/jdk{{ jdk7_version }}
+    dest=/usr/local/{{  symlink_to  }}
+    owner=root group=root
+  tags: java7

--- a/vaygrant/provisioning/roles/zipkin/files/collector-dev.scala
+++ b/vaygrant/provisioning/roles/zipkin/files/collector-dev.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.zipkin.builder.Scribe
+import com.twitter.zipkin.anormdb.{StorageBuilder, IndexBuilder, AggregatesBuilder}
+import com.twitter.zipkin.storage.anormdb.{DB, DBConfig, DBParams}
+import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
+import com.twitter.zipkin.storage.Store
+
+val db = DB(new DBConfig(name = "sqlite-persistent", params = DBParams(dbName = "/opt/zipkin/zipkin-collector"), install = true))
+val anormBuilder = Store.Builder(
+  StorageBuilder(db),
+  IndexBuilder(db),
+  AggregatesBuilder(db)
+)
+
+CollectorServiceBuilder(Scribe.Interface(categories = Set("zipkin")))
+  .writeTo(anormBuilder)

--- a/vaygrant/provisioning/roles/zipkin/files/query-dev.scala
+++ b/vaygrant/provisioning/roles/zipkin/files/query-dev.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.zipkin.builder.QueryServiceBuilder
+import com.twitter.zipkin.anormdb.{StorageBuilder, IndexBuilder, AggregatesBuilder}
+import com.twitter.zipkin.storage.anormdb.{DB, DBConfig, DBParams}
+import com.twitter.zipkin.storage.Store
+
+
+val db = DB(new DBConfig(name = "sqlite-persistent", params = DBParams(dbName = "/opt/zipkin/zipkin-query"), install = true))
+val storeBuilder = Store.Builder(
+  StorageBuilder(db),
+  IndexBuilder(db),
+  AggregatesBuilder(db)
+)
+
+QueryServiceBuilder(storeBuilder)

--- a/vaygrant/provisioning/roles/zipkin/files/query-dev.scala
+++ b/vaygrant/provisioning/roles/zipkin/files/query-dev.scala
@@ -19,7 +19,7 @@ import com.twitter.zipkin.storage.anormdb.{DB, DBConfig, DBParams}
 import com.twitter.zipkin.storage.Store
 
 
-val db = DB(new DBConfig(name = "sqlite-persistent", params = DBParams(dbName = "/opt/zipkin/zipkin-query"), install = true))
+val db = DB(new DBConfig(name = "sqlite-persistent", params = DBParams(dbName = "/opt/zipkin/zipkin-collector"), install = false))
 val storeBuilder = Store.Builder(
   StorageBuilder(db),
   IndexBuilder(db),

--- a/vaygrant/provisioning/roles/zipkin/files/supervisord.conf
+++ b/vaygrant/provisioning/roles/zipkin/files/supervisord.conf
@@ -1,5 +1,7 @@
 [program:zipkin-collector]
-command = /usr/bin/java -Xmn1000m -Xms2000m -Xmx2000m -cp /opt/zipkin/zipkin-collector-service-1.1.0/libs -jar /opt/zipkin/zipkin-collector-service-1.1.0/zipkin-collector-service-1.1.0.jar -f /opt/zipkin/zipkin-collector-service-1.1.0/config/collector-dev.scala
+directory = "/opt/zipkin"
+environment = JAVA_HOME="/usr/local/java7",PATH="/usr/local/java7/bin:%(ENV_PATH)s"
+command = /usr/local/java7/jre/bin/java -Xmn1000m -Xms2000m -Xmx2000m -cp /opt/zipkin/zipkin-collector-service-1.1.0/libs -jar /opt/zipkin/zipkin-collector-service-1.1.0/zipkin-collector-service-1.1.0.jar -f /opt/zipkin/collector-dev.scala
 user = zipkin
 autostart = true
 stopwaitsecs = 10
@@ -10,7 +12,9 @@ logfile_maxbytes = 10MB
 logfile_backups = 10
 
 [program:zipkin-query]
-command = /usr/bin/java -cp /opt/zipkin/zipkin-query-service-1.1.0/libs -jar /opt/zipkin/zipkin-query-service-1.1.0/zipkin-query-service-1.1.0.jar -f /opt/zipkin/zipkin-query-service-1.1.0/config/query-dev.scala
+directory = "/opt/zipkin"
+environment = JAVA_HOME="/usr/local/java7",PATH="/usr/local/java7/bin:%(ENV_PATH)s"
+command = /usr/local/java7/jre/bin/java -cp /opt/zipkin/zipkin-query-service-1.1.0/libs -jar /opt/zipkin/zipkin-query-service-1.1.0/zipkin-query-service-1.1.0.jar -f /opt/zipkin/query-dev.scala
 user = zipkin
 autostart = true
 stopwaitsecs = 10
@@ -21,7 +25,9 @@ logfile_maxbytes = 10MB
 logfile_backups = 10
 
 [program:zipkin-web]
-command = /usr/bin/java -cp /opt/zipkin/zipkin-web-1.1.0/libs -jar /opt/zipkin/zipkin-web-1.1.0/zipkin-web-1.1.0.jar -f /opt/zipkin/zipkin-web-1.1.0/config/web-dev.scala -D local_docroot=/opt/zipkin/zipkin-web/src/main/resources -zipkin.web.port="new InetSocketAddress(8085)" -zipkin.web.rootUrl="http://localhost:8085/"
+directory = "/opt/zipkin"
+environment = JAVA_HOME="/usr/local/java7",PATH="/usr/local/java7/bin:%(ENV_PATH)s"
+command = /usr/local/java7/jre/bin/java -cp /opt/zipkin/zipkin-web-1.1.0/libs -jar /opt/zipkin/zipkin-web-1.1.0/zipkin-web-1.1.0.jar -f /opt/zipkin/web-dev.scala -D local_docroot=/opt/zipkin/zipkin-web/zipkin-web/src/main/resources
 user = zipkin
 autostart = true
 stopwaitsecs = 10

--- a/vaygrant/provisioning/roles/zipkin/files/supervisord.conf
+++ b/vaygrant/provisioning/roles/zipkin/files/supervisord.conf
@@ -1,0 +1,46 @@
+[program:zipkin-collector]
+command = /usr/bin/java -Xmn1000m -Xms2000m -Xmx2000m -cp /opt/zipkin/zipkin-collector-service-1.1.0/libs -jar /opt/zipkin/zipkin-collector-service-1.1.0/zipkin-collector-service-1.1.0.jar -f /opt/zipkin/zipkin-collector-service-1.1.0/config/collector-dev.scala
+user = zipkin
+autostart = true
+stopwaitsecs = 10
+log_stdout = true
+log_stderr = true
+logfile = /var/log/supervisor/zipkin-collector.log
+logfile_maxbytes = 10MB
+logfile_backups = 10
+
+[program:zipkin-query]
+command = /usr/bin/java -cp /opt/zipkin/zipkin-query-service-1.1.0/libs -jar /opt/zipkin/zipkin-query-service-1.1.0/zipkin-query-service-1.1.0.jar -f /opt/zipkin/zipkin-query-service-1.1.0/config/query-dev.scala
+user = zipkin
+autostart = true
+stopwaitsecs = 10
+log_stdout = true
+log_stderr = true
+logfile = /var/log/supervisor/zipkin-query.log
+logfile_maxbytes = 10MB
+logfile_backups = 10
+
+[program:zipkin-web]
+command = /usr/bin/java -cp /opt/zipkin/zipkin-web-1.1.0/libs -jar /opt/zipkin/zipkin-web-1.1.0/zipkin-web-1.1.0.jar -f /opt/zipkin/zipkin-web-1.1.0/config/web-dev.scala -D local_docroot=/opt/zipkin/zipkin-web/src/main/resources -zipkin.web.port="new InetSocketAddress(8085)" -zipkin.web.rootUrl="http://localhost:8085/"
+user = zipkin
+autostart = true
+stopwaitsecs = 10
+log_stdout = true
+log_stderr = true
+logfile = /var/log/supervisor/zipkin-web.log
+logfile_maxbytes = 10MB
+logfile_backups = 10
+
+[supervisord]
+http_port = /tmp/supervisor.sock
+pidfile = /var/run/supervisord.pid
+minfds = 1024
+minprocs = 200
+nodaemon = false
+loglevel = info
+logfile = /var/log/supervisor/supervisord.log
+logfile_maxbytes = 10MB
+logfile_backups = 10
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock

--- a/vaygrant/provisioning/roles/zipkin/files/web-dev.scala
+++ b/vaygrant/provisioning/roles/zipkin/files/web-dev.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.finagle.zipkin.thrift.ZipkinTracer
+import com.twitter.zipkin.builder.{QueryClient, WebBuilder, ZipkinServerBuilder}
+import java.net.{InetSocketAddress, InetAddress}
+
+val queryClient = QueryClient.static(new InetSocketAddress("127.0.0.1", 9411)) map {
+  _.tracer(ZipkinTracer.mk())
+}
+WebBuilder("http://localhost:8085/", queryClient, serverBuilder = ZipkinServerBuilder(8085, 9902))

--- a/vaygrant/provisioning/roles/zipkin/tasks/main.yml
+++ b/vaygrant/provisioning/roles/zipkin/tasks/main.yml
@@ -2,67 +2,120 @@
   command: >
     wget -O /tmp/zipkin-1.1.0-src.zip https://github.com/openzipkin/zipkin/archive/1.1.0.zip
     creates=/tmp/zipkin-1.1.0-src.zip
+  tags: zipkin
 
 - name: Download Zipkin Web
   command: >
     wget -O /tmp/zipkin-web.zip https://github.com/openzipkin/zipkin/releases/download/1.1.0/zipkin-web.zip
     creates=/tmp/zipkin-web.zip
+  tags: zipkin
 
 - name: Download Zipkin Query Service
   command: >
     wget -O /tmp/zipkin-query-service.zip https://github.com/openzipkin/zipkin/releases/download/1.1.0/zipkin-query-service.zip
     creates=/tmp/zipkin-query-service.zip
+  tags: zipkin
+
 
 - name: Download Zipkin Collector Service
   command: >
     wget -O /tmp/zipkin-collector-service.zip https://github.com/openzipkin/zipkin/releases/download/1.1.0/zipkin-collector-service.zip
     creates=/tmp/zipkin-collector-service.zip
+  tags: zipkin
 
 - name: Make sure supervisord is installed
   yum: name=supervisor state=installed
+  tags: zipkin
 
 - name: Make sure unzip is installed
   yum: name=unzip state=installed
+  tags: zipkin
 
 - name: Add Zipkin group
   group: name=zipkin
+  tags: zipkin
 
 - name: Add Zipkin user
   user: name=zipkin group=zipkin comment="Zipkin user"
+  tags: zipkin
 
 - name: Make sure zipkin directory exists
   file: path=/opt/zipkin state=directory owner=zipkin group=zipkin
+  tags: zipkin
 
 - name: Make sure zipkin/zipkin-web directory exists
   file: path=/opt/zipkin/zipkin-web state=directory owner=zipkin group=zipkin
+  tags: zipkin
+
+- name: Check if zipkin source extracted
+  stat: path=/opt/zipkin/zipkin-1.1.0
+  register: zipkin_source_stat
 
 - name: Extract Zipkin Source (Zipkin Web only)
   command:
     unzip /tmp/zipkin-1.1.0-src.zip "zipkin-1.1.0/zipkin-web/*" -d /opt/zipkin
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
 
 - name: Move Zipkin Web Source folder
   command:
     mv /opt/zipkin/zipkin-1.1.0/zipkin-web /opt/zipkin/zipkin-web
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
 
 - name: Extract Zipkin Web
   command:
     unzip /tmp/zipkin-web.zip -d /opt/zipkin
     creates=/opt/zipkin/zipkin-web-1.1.0
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
 
 - name: Extract Zipkin Query Service
   command:
     unzip /tmp/zipkin-query-service.zip -d /opt/zipkin
     creates=/opt/zipkin/zipkin-query-service-1.1.0
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
 
 - name: Extract Zipkin Collector Service
   command:
     unzip /tmp/zipkin-collector-service.zip -d /opt/zipkin
     creates=/opt/zipkin/zipkin-collector-service-1.1.0
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
+
+- name: Copy Zipkin collector service config
+  copy: >
+    src=collector-dev.scala dest=/opt/zipkin/collector-dev.scala
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
+
+- name: Copy Zipkin query service config
+  copy: >
+    src=query-dev.scala dest=/opt/zipkin/query-dev.scala
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
+
+- name: Copy Zipkin web service config
+  copy: >
+    src=web-dev.scala dest=/opt/zipkin/web-dev.scala
+  sudo: yes
+  sudo_user: zipkin
+  tags: zipkin
 
 - name: Set up supervisord to run Zipkin
   copy: >
     src=supervisord.conf dest=/etc/supervisord.conf
     owner=root group=root mode=755
+  tags: zipkin
 
 - name: Start Zipkin via supervisord
   service: name=supervisord state=started enabled=yes
+  tags: zipkin

--- a/vaygrant/provisioning/roles/zipkin/tasks/main.yml
+++ b/vaygrant/provisioning/roles/zipkin/tasks/main.yml
@@ -1,0 +1,68 @@
+- name: Download Zipkin Source
+  command: >
+    wget -O /tmp/zipkin-1.1.0-src.zip https://github.com/openzipkin/zipkin/archive/1.1.0.zip
+    creates=/tmp/zipkin-1.1.0-src.zip
+
+- name: Download Zipkin Web
+  command: >
+    wget -O /tmp/zipkin-web.zip https://github.com/openzipkin/zipkin/releases/download/1.1.0/zipkin-web.zip
+    creates=/tmp/zipkin-web.zip
+
+- name: Download Zipkin Query Service
+  command: >
+    wget -O /tmp/zipkin-query-service.zip https://github.com/openzipkin/zipkin/releases/download/1.1.0/zipkin-query-service.zip
+    creates=/tmp/zipkin-query-service.zip
+
+- name: Download Zipkin Collector Service
+  command: >
+    wget -O /tmp/zipkin-collector-service.zip https://github.com/openzipkin/zipkin/releases/download/1.1.0/zipkin-collector-service.zip
+    creates=/tmp/zipkin-collector-service.zip
+
+- name: Make sure supervisord is installed
+  yum: name=supervisor state=installed
+
+- name: Make sure unzip is installed
+  yum: name=unzip state=installed
+
+- name: Add Zipkin group
+  group: name=zipkin
+
+- name: Add Zipkin user
+  user: name=zipkin group=zipkin comment="Zipkin user"
+
+- name: Make sure zipkin directory exists
+  file: path=/opt/zipkin state=directory owner=zipkin group=zipkin
+
+- name: Make sure zipkin/zipkin-web directory exists
+  file: path=/opt/zipkin/zipkin-web state=directory owner=zipkin group=zipkin
+
+- name: Extract Zipkin Source (Zipkin Web only)
+  command:
+    unzip /tmp/zipkin-1.1.0-src.zip "zipkin-1.1.0/zipkin-web/*" -d /opt/zipkin
+
+- name: Move Zipkin Web Source folder
+  command:
+    mv /opt/zipkin/zipkin-1.1.0/zipkin-web /opt/zipkin/zipkin-web
+
+- name: Extract Zipkin Web
+  command:
+    unzip /tmp/zipkin-web.zip -d /opt/zipkin
+    creates=/opt/zipkin/zipkin-web-1.1.0
+
+- name: Extract Zipkin Query Service
+  command:
+    unzip /tmp/zipkin-query-service.zip -d /opt/zipkin
+    creates=/opt/zipkin/zipkin-query-service-1.1.0
+
+- name: Extract Zipkin Collector Service
+  command:
+    unzip /tmp/zipkin-collector-service.zip -d /opt/zipkin
+    creates=/opt/zipkin/zipkin-collector-service-1.1.0
+
+- name: Set up supervisord to run Zipkin
+  copy: >
+    src=supervisord.conf dest=/etc/supervisord.conf
+    owner=root group=root mode=755
+
+- name: Start Zipkin via supervisord
+  service: name=supervisord state=started enabled=yes


### PR DESCRIPTION
This sets up Zipkin 1.1.0 in the Vagrant Box with persistent SQLite DBs for the collector and query services, and exposes zipkin-web on port 8085. It seems Zipkin 1.1.0 doesn't run on Java 8, so I also added a Java 7 role which is nearly identical to Java 8.

In order to show Zipkin in action though, we'll need to either add traces that are over the threshold it needs, or lower its threshold for collecting traces. Also, I'm not sure if we need to add Span information somehow on the sample echo endpoint in the "getting started" guide.

- [x] Create a simple scenario that will force creation of traces to demonstrate Zipkin