### PR TITLE
Add ReverseRoutes as a pattern to ignore

### DIFF
--- a/project/Scoverage.scala
+++ b/project/Scoverage.scala
@@ -7,6 +7,6 @@ object Scoverage {
 
   val settings = Seq(
     coverageHighlighting := true,
-    coverageExcludedFiles := Seq(".*(classes|src)_managed.*", ".*twirl/.*").mkString(";")
+    coverageExcludedFiles := Seq(".*(classes|src)_managed.*", ".*twirl/.*", ".*ReverseRoutes.*", ".*routes.*").mkString(";")
   )
 }


### PR DESCRIPTION
It used to be that routes were generated in src|classes_managed but with 2.4.x it looks like this has changed.
