### PR TITLE
refs !180; Proxy overriding - fixed on review comments (Re: #187)

### DIFF
--- a/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
@@ -98,7 +98,7 @@ trait HttpPartRequestHandler extends Handler {
       AggregateRequestIdHeader -> partRequestInfo.requestMeta.id,
       PartRequestIdHeader -> partRequestInfo.partRequestId,
       PartIdHeader -> partRequestInfo.partRequest.partId
-    )
+    ) ++ partRequestInfo.requestMeta.proxyId.map { case s => ProxyIdHeader -> s }
   }
 
   /**
@@ -178,6 +178,7 @@ object HttpPartRequestHandler {
   val AggregateRequestIdHeader = "X-OCTOPARTS-PARENT-REQUEST-ID"
   val PartRequestIdHeader = "X-OCTOPARTS-REQUEST-ID"
   val PartIdHeader = "X-OCTOPARTS-PART-ID"
+  val ProxyIdHeader = "X-OCTOPARTS-PROXY-ID"
 
   /**
    * A regex for matching "${...}" placeholders in strings

--- a/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
@@ -87,18 +87,18 @@ trait HttpPartRequestHandler extends Handler {
       }
       val headers = {
         collectHeaders(hArgs) ++
-          buildTracingHeaders(partRequestInfo) ++
+          buildOctopartsHeaders(partRequestInfo) ++
           tracingSpan.fold(Map.empty[String, String])(zipkinService.spanToIdsMap)
       }
     }
   }
 
-  private def buildTracingHeaders(partRequestInfo: PartRequestInfo): Seq[(String, String)] = {
+  private def buildOctopartsHeaders(partRequestInfo: PartRequestInfo): Seq[(String, String)] = {
     Seq(
       AggregateRequestIdHeader -> partRequestInfo.requestMeta.id,
       PartRequestIdHeader -> partRequestInfo.partRequestId,
       PartIdHeader -> partRequestInfo.partRequest.partId
-    ) ++ partRequestInfo.requestMeta.proxyId.map { case s => ProxyIdHeader -> s }
+    ) ++ partRequestInfo.requestMeta.proxyId.map { s => ProxyIdHeader -> s }
   }
 
   /**

--- a/app/com/m3/octoparts/aggregator/service/PartRequestService.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartRequestService.scala
@@ -13,7 +13,7 @@ class PartRequestService(
   val repository: ConfigsRepository,
   val handlerFactory: HttpHandlerFactory,
   implicit val zipkinService: ZipkinServiceLike,
-  val proxyDefinitions: Map[String, String] = Map())(implicit val executionContext: ExecutionContext)
+  proxyDefinitions: Map[String, String])(implicit val executionContext: ExecutionContext)
     extends PartRequestServiceBase {
 
   override def proxyDefinition(proxyId: String): Option[String] = proxyDefinitions.get(proxyId)

--- a/app/com/m3/octoparts/aggregator/service/PartRequestService.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartRequestService.scala
@@ -12,5 +12,9 @@ import scala.concurrent.ExecutionContext
 class PartRequestService(
   val repository: ConfigsRepository,
   val handlerFactory: HttpHandlerFactory,
-  implicit val zipkinService: ZipkinServiceLike)(implicit val executionContext: ExecutionContext)
-    extends PartRequestServiceBase
+  implicit val zipkinService: ZipkinServiceLike,
+  val proxyDefinitions: Map[String, String] = Map())(implicit val executionContext: ExecutionContext)
+    extends PartRequestServiceBase {
+
+  override def proxyDefinition(proxyId: String): Option[String] = proxyDefinitions.get(proxyId)
+}

--- a/app/com/m3/octoparts/aggregator/service/RequestParamSupport.scala
+++ b/app/com/m3/octoparts/aggregator/service/RequestParamSupport.scala
@@ -71,7 +71,8 @@ trait RequestParamSupport {
       "meta.serviceId" -> meta.serviceId,
       "meta.sessionId" -> meta.sessionId,
       "meta.userAgent" -> meta.userAgent,
-      "meta.userId" -> meta.userId
+      "meta.userId" -> meta.userId,
+      "meta.proxyId" -> meta.proxyId
     )
     value <- mbValue
   } yield {

--- a/app/views/part/test.scala.html
+++ b/app/views/part/test.scala.html
@@ -1,6 +1,6 @@
 @(part: presentation.HttpPartConfigView)(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
 
-@metaProps = @{Seq("serviceId", "userId", "sessionId", "requestUrl", "userAgent")}
+@metaProps = @{Seq("serviceId", "userId", "sessionId", "requestUrl", "userAgent", "proxyId")}
 
 @requiredCls(paramView: presentation.ParamView)= {if (required) "required" else "optional"}
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -168,4 +168,10 @@ zipkin {
   sampleRate = ${?OCTOPARTS_ZIPKIN_SAMPLE_RATE}
 }
 
+# Proxy Override
+# The mapping from meta.proxyId (taken from X-OCTOPARTS-PROXY-ID HTTP header) to proxy URL
+proxies = [
+  # { id: "proxy1", url: "http://proxy1:8080" }
+]
+
 play.modules.disabled += "play.api.db.DBModule"

--- a/conf/application.dev.conf.sample
+++ b/conf/application.dev.conf.sample
@@ -22,4 +22,10 @@ caching {
   inmemory = true
 }
 
+proxies = [
+  # The mapping from meta.proxyId (taken from X-OCTOPARTS-PROXY-ID HTTP header) to proxy URL
+  { id: "proxy1", url: "http://proxy1:8080" },
+  { id: "proxy2", url: "http://proxy2:8080" },
+]
+
 swagger.api.basepath="http://localhost:9000"

--- a/java-client/src/main/scala/com/m3/octoparts/client/OctopartsApiBuilder.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/OctopartsApiBuilder.scala
@@ -50,11 +50,17 @@ class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: Stri
    * @param userAgent optional user agent
    * @param requestUrl optional request URL
    * @param timeoutMs This value is enforced in the octoparts server.
+   * @param proxyId proxy Id defined in Octoparts' configuration, taken from HTTP header 'X-OCTOPARTS-PROXY-ID'
    */
-  def newRequest(@Nullable userId: String, @Nullable sessionId: String, @Nullable userAgent: String, @Nullable requestUrl: String, @Nullable timeoutMs: java.lang.Long): RequestBuilder = {
+  def newRequest(@Nullable userId: String, @Nullable sessionId: String, @Nullable userAgent: String, @Nullable requestUrl: String, @Nullable timeoutMs: java.lang.Long, @Nullable proxyId: String): RequestBuilder = {
     val timeoutOpt = if (timeoutMs == null) None else Some(timeoutMs.longValue().millis)
-    val requestMeta = RequestMeta(UUID.randomUUID.toString, Option(serviceId), Option(userId), Option(sessionId), Option(requestUrl), Option(userAgent), timeoutOpt)
+    val requestMeta = RequestMeta(UUID.randomUUID.toString, Option(serviceId), Option(userId), Option(sessionId), Option(requestUrl), Option(userAgent), timeoutOpt, Option(proxyId))
     new RequestBuilder(requestMeta)
+  }
+
+  /** for backward compatibility */
+  def newRequest(@Nullable userId: String, @Nullable sessionId: String, @Nullable userAgent: String, @Nullable requestUrl: String, @Nullable timeoutMs: java.lang.Long): RequestBuilder = {
+    newRequest(userId, sessionId, userAgent, requestUrl, timeoutMs, null);
   }
 
   @varargs private[client] def toHttp(aggregateRequest: AggregateRequest, additionalHeaders: (String, String)*) = {

--- a/java-client/src/test/scala/com/m3/octoparts/client/OctopartsApiBuilderTest.scala
+++ b/java-client/src/test/scala/com/m3/octoparts/client/OctopartsApiBuilderTest.scala
@@ -32,6 +32,11 @@ class OctopartsApiBuilderTest extends FunSpec with BeforeAndAfterAll with Matche
     JListWrapper(ningrequest.getHeaders.get("a")).toSeq shouldBe Seq("b")
   }
 
+  it("should handle proxy-id meta") {
+    val request = apiBuilder.newRequest("123", "cafebabe", null, "/index.jsp", 456L, "test1")
+    request.build.requestMeta.proxyId should be(Some("test1"))
+  }
+
   it("should escape var arguments, handling nulls") {
     OctopartsApiBuilder.formatWithUriEscape("%s", " ") should be("%20")
     OctopartsApiBuilder.formatWithUriEscape("%s%s", " ", " ") should be("%20%20")

--- a/models/src/main/scala/com/m3/octoparts/model/AggregateRequest.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/AggregateRequest.scala
@@ -23,7 +23,8 @@ case class RequestMeta(
   @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty sessionId: Option[String] = None,
   @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty requestUrl: Option[String] = None,
   @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty userAgent: Option[String] = None,
-  @(ApiModelProperty @field)(required = false, dataType = "integer", value = "in ms")@BeanProperty timeout: Option[FiniteDuration] = None)
+  @(ApiModelProperty @field)(required = false, dataType = "integer", value = "in ms")@BeanProperty timeout: Option[FiniteDuration] = None,
+  @(ApiModelProperty @field)(required = false, dataType = "String")@BeanProperty proxyId: Option[String] = None)
 
 /**
  * A request for a given part. One of more of these can be combined into a single AggregateRequest.

--- a/test/com/m3/octoparts/aggregator/service/PartRequestServiceSpec.scala
+++ b/test/com/m3/octoparts/aggregator/service/PartRequestServiceSpec.scala
@@ -1,12 +1,16 @@
 package com.m3.octoparts.aggregator.service
 
+import java.util.concurrent.TimeUnit
+
+import com.beachape.logging.LTSVLogger
 import com.beachape.zipkin.services.NoopZipkinService
 import com.m3.octoparts.aggregator.PartRequestInfo
 import com.m3.octoparts.model._
-import com.m3.octoparts.model.config.{ HttpPartConfig, PartParam }
+import com.m3.octoparts.model.config.{ Charset, HttpPartConfig, PartParam }
 import com.m3.octoparts.repository.ConfigsRepository
 import com.m3.octoparts.support.mocks.HandlerMocks
 import com.twitter.zipkin.gen.Span
+import org.joda.time.{ DateTime }
 import org.mockito.Matchers.{ eq => mockitoEq, _ }
 import org.mockito.Mockito._
 import org.scalatest._
@@ -15,6 +19,7 @@ import org.scalatest.mock.MockitoSugar
 
 import scala.collection.SortedSet
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 class PartRequestServiceSpec
     extends FunSpec
@@ -26,16 +31,63 @@ class PartRequestServiceSpec
 
   implicit val emptySpan = new Span()
   val repository = mock[ConfigsRepository]
-  val config = mock[HttpPartConfig]
-  doReturn(SortedSet.empty[PartParam]).when(config).parameters
-  doReturn(None).when(config).deprecatedInFavourOf
-  doReturn("123").when(config).partId
+  val config = HttpPartConfig(
+    Some(1), "123", "owner", Some("description"), "uri", HttpMethod.Get,
+    SortedSet.empty, 1, Duration(1, TimeUnit.SECONDS), Duration(1, TimeUnit.SECONDS), Charset.forName("UTF-8"), None, SortedSet.empty,
+    None, None, SortedSet.empty, Some(Duration.Zero), false,
+    None, None, Duration(1, TimeUnit.SECONDS), None, false, None, DateTime.now, DateTime.now)
+
+  val proxyDef = Map("test1" -> "http://mrkuntest1:8888", "test2" -> "http://mrkuntest2:8888")
 
   def pReq(partId: String) = PartRequestInfo(RequestMeta("hi"), PartRequest(partId = partId, id = Some("myId")))
+  def pReqWithProxy(partId: String, proxy: Option[String]) = PartRequestInfo(RequestMeta("hi", proxyId = proxy), PartRequest(partId = partId, id = Some("myId")))
 
   describe("#responseFor") {
 
+    describe("when given a proxy Id") {
+      val service = new PartRequestService(repository, mockVoidHttpProxyHandlerFactory, NoopZipkinService, proxyDef)
+      val proxyConfig = config.copy(httpProxy = Some("default"))
+
+      it("should not use proxy when no proxy-id is set in both of requestMeta and partConfig") {
+        doReturn(Future.successful(Some(config))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
+        whenReady(service.responseFor(pReq("123"))) { r =>
+          r.contents should be(Some("it worked with proxy None"))
+        }
+      }
+
+      it("should not override proxy when no proxy-id is set in requestMeta") {
+        val proxyConfig = config.copy(httpProxy = Some("default"))
+        doReturn(Future.successful(Some(proxyConfig))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
+        whenReady(service.responseFor(pReq("123"))) { r =>
+          r.contents should be(Some("it worked with proxy Some(default)"))
+        }
+      }
+
+      it("should return a Future[PartResponse] that is filled by proxy response") {
+        doReturn(Future.successful(Some(config))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
+        whenReady(service.responseFor(pReqWithProxy("123", Some("test1")))) { r =>
+          r.contents should be(Some("it worked with proxy Some(http://mrkuntest1:8888)"))
+        }
+      }
+
+      it("should override proxy setting in partconfig") {
+        doReturn(Future.successful(Some(proxyConfig))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
+        whenReady(service.responseFor(pReqWithProxy("123", Some("test1")))) { r =>
+          r.contents should be(Some("it worked with proxy Some(http://mrkuntest1:8888)"))
+        }
+      }
+
+      it("should not override proxy when proxy-id is not found in configuration") {
+        doReturn(Future.successful(Some(config))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
+        val pReqWithProxy = pReq("123").copy(requestMeta = RequestMeta("hi", proxyId = Some("unknown")))
+        whenReady(service.responseFor(pReqWithProxy)) { r =>
+          r.contents should be(Some("it worked with proxy None"))
+        }
+      }
+    }
+
     describe("when given a PartRequest with a partId that is not supported") {
+      LTSVLogger.info("warming up logger... without this, 'testOnly' for this spec will fail by timeout of Future")
       it("should return a Future[PartResponse] with an error that mentions that the part Id is not supported") {
         val service = new PartRequestService(repository, mockVoidHttpHandlerFactory, NoopZipkinService)
         doReturn(Future.successful(None)).when(repository).findConfigByPartId(anyObject[String]())(anyObject[Span])
@@ -59,8 +111,8 @@ class PartRequestServiceSpec
       }
       it("should return a Future[PartResponse] when given a part id for a config that has deprecatedInFavourOf filled in") {
         val service = new PartRequestService(repository, mockVoidHttpHandlerFactory, NoopZipkinService)
-        doReturn(Some("helloWorldPart")).when(config).deprecatedInFavourOf
-        doReturn(Future.successful(Some(config))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
+        val deprecatedConfig = config.copy(deprecatedInFavourOf = Some("helloWorldPart"))
+        doReturn(Future.successful(Some(deprecatedConfig))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
         whenReady(service.responseFor(pReq("123"))) { r =>
           r.warnings should be(Seq(service.deprecationMsg("123", "helloWorldPart")))
           r.contents should be(Some("it worked"))
@@ -82,15 +134,14 @@ class PartRequestServiceSpec
       it("should return a Future with a PartResponse that contains that errors sequence") {
         val service = new PartRequestService(repository, mockPartResponseWithErrorHttpHandlerFactory, NoopZipkinService)
         doReturn(Future.successful(Some(config))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
-        doReturn(None).when(config).deprecatedInFavourOf
         whenReady(service.responseFor(pReq("123"))) { r =>
           r.errors should be(Seq("SomeException"))
         }
       }
       it("should return a Future with a PartResponse that contains that errors sequence and a deprecation warning if the dependency is deprecated") {
         val service = new PartRequestService(repository, mockPartResponseWithErrorHttpHandlerFactory, NoopZipkinService)
-        doReturn(Future.successful(Some(config))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
-        doReturn(Some("HelloWorld")).when(config).deprecatedInFavourOf
+        val deprecatedConfig = config.copy(deprecatedInFavourOf = Some("HelloWorld"))
+        doReturn(Future.successful(Some(deprecatedConfig))).when(repository).findConfigByPartId(mockitoEq("123"))(anyObject[Span])
         whenReady(service.responseFor(pReq("123"))) { r =>
           r.errors should be(Seq("SomeException"))
           r.warnings should be(Seq(service.deprecationMsg("123", "HelloWorld")))

--- a/test/com/m3/octoparts/support/mocks/HandlerMocks.scala
+++ b/test/com/m3/octoparts/support/mocks/HandlerMocks.scala
@@ -17,6 +17,10 @@ trait HandlerMocks {
     val partId = "voidHandler"
     def process(pri: PartRequestInfo, args: HandlerArguments)(implicit span: Span) = Future.successful(PartResponse(partId, partId, contents = Some("it worked")))
   }
+  def mockVoidProxyHandler(proxy: Option[String]) = new Handler {
+    val partId = "voidProxyHandler"
+    def process(pri: PartRequestInfo, args: HandlerArguments)(implicit span: Span) = Future.successful(PartResponse(partId, partId, contents = Some(s"it worked with proxy ${proxy}")))
+  }
   val mockErrorHandler = new Handler {
     val partId = "errorHandler"
     def process(pri: PartRequestInfo, args: HandlerArguments)(implicit span: Span) = Future.failed(new RuntimeException)
@@ -28,6 +32,10 @@ trait HandlerMocks {
   val mockVoidHttpHandlerFactory = new HttpHandlerFactory {
     implicit val zipkinService = NoopZipkinService
     override def makeHandler(ci: HttpPartConfig) = mockVoidHandler
+  }
+  val mockVoidHttpProxyHandlerFactory = new HttpHandlerFactory {
+    implicit val zipkinService = NoopZipkinService
+    override def makeHandler(ci: HttpPartConfig) = mockVoidProxyHandler(ci.httpProxy)
   }
   val mockErrorHttpHandlerFactory = new HttpHandlerFactory {
     implicit val zipkinService = NoopZipkinService

--- a/test/controllers/PartsControllerSpec.scala
+++ b/test/controllers/PartsControllerSpec.scala
@@ -54,7 +54,7 @@ class PartsControllerSpec extends FlatSpec with Matchers with MockitoSugar with 
       case "void" => voidHandler
       case _ => throw new RuntimeException
     }
-  }, NoopZipkinService)
+  }, NoopZipkinService, Map.empty)
   private val partsService = new PartsService(partsRequestService)
 
   private val controller = new PartsController(partsService, configsRepository, 10 seconds, true, actorSystem, NoopZipkinService)


### PR DESCRIPTION
Thank you for reviewing!

Done:
- Test for HTTP header check
- PR from forked branch
- some syntax fix, take away default argument

Progress:
- Log an alert when invalid proxy

@lloydmeta , As for using repository to keep proxy settings, I suggest that this time how about introduce this feature (with application.conf) as "experimental" state. 

Because @xevix is also telling that setting might be more flexible, I agree with that idea, but I need to try this feature on our testing environment to check if it works as expected (including tester operation). 

I guess we'll have another finding from that operational test.

EDIT: I thought that if using in "experimental" state, changing client API might be affects too much(newRequest supposed to require proxyId) . Another idea is to use "additionalHeader" argument to specify proxyId by "X-OCTOPARTS-PROXY-ID" header.  This doesn't need updating octoparts jar in client application.
