### PR TITLE
Move Page definition objects into separate trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ jdk:
 scala:
   - 2.11.7
 env:
-  - SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256m -XX:MaxPermSize=512m -Xms128m -Xmx512m"
-  - JAVA_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256m -XX:MaxPermSize=512m -Xms1024m -Xmx1024m"
+  - SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256m -XX:MaxPermSize=512m -Xms128m -Xmx512m" JAVA_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256m -XX:MaxPermSize=512m -Xms1024m -Xmx1024m"
 
 addons:
   postgresql: "9.3"
@@ -23,8 +22,7 @@ script:
   - find $HOME/.sbt -name "*.lock" -type f -delete && find $HOME/.ivy2/cache -name "*[\[\]\(\)]*.properties" -type f -delete
 
 after_success:
-  - sbt coverageReport
-  - sbt coverageAggregate coveralls
+  - sbt coverageReport coverageAggregate coveralls
 
 sudo: false
 

--- a/test/integration/AdminSpec.scala
+++ b/test/integration/AdminSpec.scala
@@ -3,9 +3,7 @@ package integration
 import com.m3.octoparts.model.config.json.ThreadPoolConfig
 import com.m3.octoparts.support.db.RequiresDB
 import com.m3.octoparts.support.{ PlayServerSupport, OneDIBrowserPerSuite }
-import org.openqa.selenium.support.ui.Select
 import org.scalatest.{ Matchers, FunSpec }
-import org.scalatest.selenium.{ Page => SeleniumPage }
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatestplus.play._
 
@@ -17,116 +15,8 @@ class AdminSpec
     with HtmlUnitFactory
     with Matchers
     with ScalaFutures
+    with PagesSupport
     with IntegrationPatience {
-
-  lazy val baseUrl: String = s"http://localhost:$port"
-
-  object ThreadPoolAddPage extends SeleniumPage {
-    val url: String = s"$baseUrl/admin/thread-pools/new"
-
-    def createThreadPool: ThreadPoolConfig = {
-      val name = s"my little pool $uniqueId"
-      val size = 10
-      val queueSize = 500
-      goTo(ThreadPoolAddPage)
-      textField("threadPoolKey").value = name
-      numberField("coreSize").value = s"$size"
-      numberField("queueSize").value = s"$queueSize"
-      submit()
-      ThreadPoolConfig(name, size, queueSize)
-    }
-
-  }
-
-  object PartAddPage extends SeleniumPage {
-
-    case class PartConfig(partId: String,
-                          url: String,
-                          connectionPoolSize: Int,
-                          commandKey: String,
-                          commandKeyGroup: String,
-                          proxy: String)
-
-    val url: String = s"$baseUrl/admin/parts/new"
-
-    def createPart(threadPoolConfig: ThreadPoolConfig): PartConfig = {
-      val ThreadPoolConfig(threadPoolName, coreSize, _) = threadPoolConfig
-      goTo(PartAddPage)
-      val partId = s"my little part $uniqueId"
-      val url = "http://beachape.com"
-      val connectionPoolSize = 5
-      val commandKey = s"part_key_$uniqueId"
-      val commandKeyGroup = s"part_group_$uniqueId"
-      val proxy = "http://proxy.com"
-      textField("partId").value = partId
-      urlField("httpSettings.uri").value = url
-      numberField("httpSettings.httpPoolSize").value = connectionPoolSize.toString
-      textField("hystrixConfig.commandKey").value = commandKey
-      textField("hystrixConfig.commandGroupKey").value = commandKeyGroup
-      textField("httpSettings.httpProxy").value = proxy
-      val threadPoolDropdown = new Select(webDriver.findElement(IdQuery("hystrixConfig_threadPoolConfigId").by))
-      threadPoolDropdown.selectByVisibleText(s"$threadPoolName (core size: $coreSize)")
-      submit()
-      PartConfig(
-        partId = partId,
-        url = url,
-        connectionPoolSize = connectionPoolSize,
-        commandKey = commandKey,
-        commandKeyGroup = commandKeyGroup,
-        proxy = proxy
-      )
-    }
-  }
-
-  case class PartEditPage(partId: String) extends SeleniumPage {
-    val url: String = s"$baseUrl/admin/parts/$partId/edit"
-  }
-
-  object CacheGroupListPage extends SeleniumPage {
-    val url: String = s"$baseUrl/admin/cache-groups"
-  }
-
-  object CacheGroupAddPage extends SeleniumPage {
-    val url: String = s"$baseUrl/admin/cache-groups/new"
-
-    /**
-     * Adds a Cache Group and gives back the name
-     */
-    def createCacheGroup: String = {
-      goTo(this)
-      val name = s"my little cache group $uniqueId"
-      textField("name").value = name
-      textField("description").value = "whatevs"
-      submit()
-      name
-    }
-  }
-
-  case class CacheGroupShowPage(cacheGroupName: String) extends SeleniumPage {
-    val url: String = s"$baseUrl/admin/cache-groups/$cacheGroupName/show"
-  }
-
-  case class CacheGroupEditPage(cacheGroupName: String) extends SeleniumPage {
-    val url: String = s"$baseUrl/admin/cache-groups/$cacheGroupName/edit"
-
-    def updateWithName(name: String) = {
-      goTo(this)
-      textField("name").value = name
-      submit()
-    }
-  }
-
-  case class CacheGroupDeletePage(cacheGroupName: String) extends SeleniumPage {
-    val url: String = s"$baseUrl/admin/cache-groups/$cacheGroupName/delete"
-
-    def delete() = {
-      find(TagNameQuery("input")).filter(_.attribute("value").contains("Delete")).foreach(clickOn)
-    }
-
-    def cancel() = click on linkText("Cancel")
-  }
-
-  def uniqueId = java.util.UUID.randomUUID
 
   describe("adding a thread pool") {
 

--- a/test/integration/PagesSupport.scala
+++ b/test/integration/PagesSupport.scala
@@ -1,0 +1,119 @@
+package integration
+
+import com.m3.octoparts.model.config.json.ThreadPoolConfig
+import com.m3.octoparts.support.{ PlayServerSupport, OneDIBrowserPerSuite }
+import org.scalatest.selenium.{ Page => SeleniumPage }
+import org.openqa.selenium.support.ui.Select
+
+trait PagesSupport { this: OneDIBrowserPerSuite with PlayServerSupport =>
+
+  lazy val baseUrl: String = s"http://localhost:$port"
+
+  object ThreadPoolAddPage extends SeleniumPage {
+    val url: String = s"$baseUrl/admin/thread-pools/new"
+
+    def createThreadPool: ThreadPoolConfig = {
+      val name = s"my little pool $uniqueId"
+      val size = 10
+      val queueSize = 500
+      goTo(ThreadPoolAddPage)
+      textField("threadPoolKey").value = name
+      numberField("coreSize").value = s"$size"
+      numberField("queueSize").value = s"$queueSize"
+      submit()
+      ThreadPoolConfig(name, size, queueSize)
+    }
+
+  }
+
+  object PartAddPage extends SeleniumPage {
+
+    case class PartConfig(partId: String,
+                          url: String,
+                          connectionPoolSize: Int,
+                          commandKey: String,
+                          commandKeyGroup: String,
+                          proxy: String)
+
+    val url: String = s"$baseUrl/admin/parts/new"
+
+    def createPart(threadPoolConfig: ThreadPoolConfig): PartConfig = {
+      val ThreadPoolConfig(threadPoolName, coreSize, _) = threadPoolConfig
+      goTo(PartAddPage)
+      val partId = s"my little part $uniqueId"
+      val url = "http://beachape.com"
+      val connectionPoolSize = 5
+      val commandKey = s"part_key_$uniqueId"
+      val commandKeyGroup = s"part_group_$uniqueId"
+      val proxy = "http://proxy.com"
+      textField("partId").value = partId
+      urlField("httpSettings.uri").value = url
+      numberField("httpSettings.httpPoolSize").value = connectionPoolSize.toString
+      textField("hystrixConfig.commandKey").value = commandKey
+      textField("hystrixConfig.commandGroupKey").value = commandKeyGroup
+      textField("httpSettings.httpProxy").value = proxy
+      val threadPoolDropdown = new Select(webDriver.findElement(IdQuery("hystrixConfig_threadPoolConfigId").by))
+      threadPoolDropdown.selectByVisibleText(s"$threadPoolName (core size: $coreSize)")
+      submit()
+      PartConfig(
+        partId = partId,
+        url = url,
+        connectionPoolSize = connectionPoolSize,
+        commandKey = commandKey,
+        commandKeyGroup = commandKeyGroup,
+        proxy = proxy
+      )
+    }
+  }
+
+  case class PartEditPage(partId: String) extends SeleniumPage {
+    val url: String = s"$baseUrl/admin/parts/$partId/edit"
+  }
+
+  object CacheGroupListPage extends SeleniumPage {
+    val url: String = s"$baseUrl/admin/cache-groups"
+  }
+
+  object CacheGroupAddPage extends SeleniumPage {
+    val url: String = s"$baseUrl/admin/cache-groups/new"
+
+    /**
+     * Adds a Cache Group and gives back the name
+     */
+    def createCacheGroup: String = {
+      goTo(this)
+      val name = s"my little cache group $uniqueId"
+      textField("name").value = name
+      textField("description").value = "whatevs"
+      submit()
+      name
+    }
+  }
+
+  case class CacheGroupShowPage(cacheGroupName: String) extends SeleniumPage {
+    val url: String = s"$baseUrl/admin/cache-groups/$cacheGroupName/show"
+  }
+
+  case class CacheGroupEditPage(cacheGroupName: String) extends SeleniumPage {
+    val url: String = s"$baseUrl/admin/cache-groups/$cacheGroupName/edit"
+
+    def updateWithName(name: String) = {
+      goTo(this)
+      textField("name").value = name
+      submit()
+    }
+  }
+
+  case class CacheGroupDeletePage(cacheGroupName: String) extends SeleniumPage {
+    val url: String = s"$baseUrl/admin/cache-groups/$cacheGroupName/delete"
+
+    def delete() = {
+      find(TagNameQuery("input")).filter(_.attribute("value").contains("Delete")).foreach(clickOn)
+    }
+
+    def cancel() = click on linkText("Cancel")
+  }
+
+  def uniqueId = java.util.UUID.randomUUID
+
+}


### PR DESCRIPTION
This makes it easier to keep track of Page definitions and makes the actual testing logic easier to read.
