### PR TITLE
Upgrade versions on important dependencies.

### DIFF
--- a/app/com/m3/octoparts/http/InstrumentedHttpClient.scala
+++ b/app/com/m3/octoparts/http/InstrumentedHttpClient.scala
@@ -100,8 +100,7 @@ class InstrumentedHttpClient(
    * A [[PoolingHttpClientConnectionManager]] which monitors the number of open connections.
    */
   private[http] class InstrumentedHttpClientConnectionMgr extends PoolingHttpClientConnectionManager {
-    // TODO use this after moving to httpclient-4.4
-    // setValidateAfterInactivity(1) // always revalidate connections
+    setValidateAfterInactivity(1) // always revalidate connections
     setDefaultMaxPerRoute(connectionPoolSize)
     setMaxTotal(connectionPoolSize)
 

--- a/app/com/m3/octoparts/wiring/CacheModule.scala
+++ b/app/com/m3/octoparts/wiring/CacheModule.scala
@@ -51,12 +51,13 @@ trait CacheModule extends UtilsModule {
         password <- configuration.getString("memcached.password")
       } yield AuthConfiguration(user, password)
 
-      val shade = Memcached(ShadeConfig(
-        addresses = hostPort,
-        operationTimeout = timeout,
-        protocol = Protocol.withName(protocol),
-        authentication = auth
-      ), cacheExecutor)
+      val shade = Memcached(
+        ShadeConfig(
+          addresses = hostPort,
+          operationTimeout = timeout,
+          protocol = Protocol.withName(protocol),
+          authentication = auth
+        ))(cacheExecutor)
 
       new LoggingRawCache(new MemcachedRawCache(shade))(cacheExecutor)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,10 +15,8 @@ object Dependencies {
 
   val thePlayVersion = play.core.PlayVersion.current
   val slf4jVersion = "1.7.10"
-  val hystrixVersion = "1.4.1"
-  // http-client 4.4 has an unsolved issue which affects us critically: https://issues.apache.org/jira/browse/HTTPCLIENT-1609
-  // Stay on 4.3.x until this is fixed.
-  val httpClientVersion = "4.3.6"
+  val hystrixVersion = "1.4.23"
+  val httpClientVersion = "4.5.1"
   val scalikejdbcVersion = "2.3.0"
   val swaggerVersion = "1.3.12"
   val jacksonVersion = "2.5.1"
@@ -37,13 +35,13 @@ object Dependencies {
   // Hystrix
   val hystrixCore         = "com.netflix.hystrix"       % "hystrix-core"                  % hystrixVersion
   val hystrixStream       = "com.netflix.hystrix"       % "hystrix-metrics-event-stream"  % hystrixVersion
-  val rxJavaScala         = "io.reactivex"              %% "rxscala"                      % "0.24.0" // compatible with the rxjava (1.0.7) used in hystrix-core. Check again if you change.
+  val rxJavaScala         = "io.reactivex"              %% "rxscala"                      % "0.26.0" // compatible with the rxjava (1.1.0) used in hystrix-core. Check again if you change.
 
   // HTTP clients
-  val asyncHttpClient     = "com.ning"                  % "async-http-client"             % "1.9.11" // not upgrading because play-ws uses this version
+  val asyncHttpClient     = "com.ning"                  % "async-http-client"             % "1.9.21" // not upgrading because play-ws uses this version
   val httpClient          = "org.apache.httpcomponents" % "httpclient"                    % httpClientVersion
   val httpClientCache     = "org.apache.httpcomponents" % "httpclient-cache"              % httpClientVersion
-  val metricsHttpClient   = "io.dropwizard.metrics"     % "metrics-httpclient"            % "3.1.1"
+  val metricsHttpClient   = "io.dropwizard.metrics"     % "metrics-httpclient"            % "3.1.2"
 
   // DB
   val postgres            = "org.postgresql"            % "postgresql"                    % "9.4-1201-jdbc41"   % Runtime
@@ -51,11 +49,10 @@ object Dependencies {
   val scalikeJdbc         = "org.scalikejdbc"           %% "scalikejdbc"                  % scalikejdbcVersion
   val scalikeJdbcConfig   = "org.scalikejdbc"           %% "scalikejdbc-config"           % scalikejdbcVersion
   val scalikeJdbcPlay     = "org.scalikejdbc"           %% "scalikejdbc-play-initializer" % "2.4.3"
-  val dbcp2               = "org.apache.commons"        % "commons-dbcp2"                 % "2.1"
+  val dbcp2               = "org.apache.commons"        % "commons-dbcp2"                 % "2.1.1"
 
   // Memcached
-  val shade               = "com.bionicspirit"          %% "shade"                        % "1.6.0"
-  val spyMemcached        = "net.spy"                   % "spymemcached"                  % "2.11.6"
+  val shade               = "com.bionicspirit"          %% "shade"                        % "1.7.2"
 
   // Play plugins
   val playFlyway          = "org.flywaydb"              %% "flyway-play"                  % "2.2.0"
@@ -75,12 +72,12 @@ object Dependencies {
 
   // Test
   val playTest            = "com.typesafe.play"         %% "play-test"                    % thePlayVersion      % Test
-  val scalatest           = "org.scalatest"             %% "scalatest"                    % "2.2.5"             % Test
-  val scalatestPlay       = "org.scalatestplus"         %% "play"                         % "1.4.0-M4"          % Test
+  val scalatest           = "org.scalatest"             %% "scalatest"                    % "2.2.6"             % Test
+  val scalatestPlay       = "org.scalatestplus"         %% "play"                         % "1.4.0"            % Test
   val scalacheck          = "org.scalacheck"            %% "scalacheck"                   % "1.12.2"            % Test
-  val groovy              = "org.codehaus.groovy"       % "groovy"                        % "2.4.1"             % Test
+  val groovy              = "org.codehaus.groovy"       %  "groovy"                       % "2.4.1"             % Test
   val scalikeJdbcTest     = "org.scalikejdbc"           %% "scalikejdbc-test"             % scalikejdbcVersion  % Test
-  val mockitoCore         =  "org.mockito"              % "mockito-core"                  % "1.10.19"           % Test
+  val mockitoCore         = "org.mockito"               % "mockito-core"                  % "1.10.19"           % Test
 
   // Misc utils
   val commonsValidator    = "commons-validator"         % "commons-validator"             % "1.4.1"             % Runtime
@@ -133,7 +130,6 @@ object Dependencies {
 
     // Memcached
     shade,
-    spyMemcached,
 
     // Zipkin
     zipkinFutures,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,11 @@
 // The Typesafe repository
 resolvers ++= Seq(
-  Resolver.typesafeRepo("releases"),
   "jgit-repo"           at "http://download.eclipse.org/jgit/maven",
   Classpaths.sbtPluginReleases
 )
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
 // scoverage for test coverage
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.4")
 // to show transitive dependencies as a graph


### PR DESCRIPTION
- Bump Play to 2.4.6 -> https://www.playframework.com/changelog
- Upgrade Apache HttpClient to 4.5.1 -> force 4.3.x behaviour by always revalidating connections for safety
- Upgrade Shade to 1.7.2; latest release -> minor change in client instantiation https://github.com/alexandru/shade/blob/master/release-notes/1.7.md
- Remove separate Spymemcached dependency declaration -> Already brought in via Shade
- Upgrade Hystrix, Hystrix Streaming -> A few fixes and improvements https://github.com/Netflix/Hystrix/blob/master/CHANGELOG.md
- Upgrade RxScala to match Hystrix's RxJava dep -> Many fixes and performance improvements RxScala release notes https://github.com/ReactiveX/RxScala/releases, RxJava release notes https://github.com/ReactiveX/RxJava/releases
- Upgrade DBCP2 -> Bug fixes http://commons.apache.org/proper/commons-dbcp/changes-report.html#a2.1.1
- Upgrade some test dependencies (Scalatest upgrade was needed to allow for Apache HTTPClient's upgrade to v4.5.1)
- Remove duplicate declaration of Typesafe releases repo as a resolver in plugins.sbt
