### PR TITLE
Closes #194 Make Play-app harnesses extend from RequiresDB

### DIFF
--- a/test/com/m3/octoparts/database/MigrationsSpec.scala
+++ b/test/com/m3/octoparts/database/MigrationsSpec.scala
@@ -1,9 +1,9 @@
 package com.m3.octoparts.database
 
+import com.m3.octoparts.support.PlayAppSupport
 import org.scalatest.FunSpec
-import com.m3.octoparts.support.db.RequiresDB
 
-class MigrationsSpec extends FunSpec with RequiresDB {
+class MigrationsSpec extends FunSpec with PlayAppSupport {
 
   describe("Running migrations") {
     describe("from an empty database") {

--- a/test/com/m3/octoparts/future/RichFutureWithTimingSpec.scala
+++ b/test/com/m3/octoparts/future/RichFutureWithTimingSpec.scala
@@ -1,6 +1,7 @@
 package com.m3.octoparts.future
 
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{ Millis, Span }
 import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.Future
@@ -8,6 +9,9 @@ import scala.concurrent.duration.Duration
 
 class RichFutureWithTimingSpec extends FlatSpec with Matchers with ScalaFutures {
   import scala.concurrent.ExecutionContext.Implicits.global
+
+  // Not quite IntegrationPatience but long enough to avoid problems on slower machines
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(Span(500, Millis))
 
   behavior of "RichFutureWithTiming"
 
@@ -44,4 +48,5 @@ class RichFutureWithTimingSpec extends FlatSpec with Matchers with ScalaFutures 
       result should be("OK")
     }
   }
+
 }

--- a/test/com/m3/octoparts/support/SpecHarnesses.scala
+++ b/test/com/m3/octoparts/support/SpecHarnesses.scala
@@ -2,6 +2,7 @@ package com.m3.octoparts.support
 
 import com.codahale.metrics.{ SharedMetricRegistries, MetricRegistry }
 import com.kenshoo.play.metrics.Metrics
+import com.m3.octoparts.support.db.{ RequiresDB, DBSuite }
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.openqa.selenium.safari.SafariDriver
@@ -64,7 +65,7 @@ trait FutureFunSpec extends FunSpec with Matchers with ScalaFutures with Integra
  *
  * DI components for the app can be accessed via the applicationBuilder member
  */
-trait PlayAppSupport extends SuiteMixin with TestAppComponents { this: Suite =>
+trait PlayAppSupport extends SuiteMixin with TestAppComponents with RequiresDB { this: Suite =>
 
   abstract override def run(testName: Option[String], args: Args): Status = {
     Play.start(app)
@@ -93,7 +94,7 @@ trait PlayAppSupport extends SuiteMixin with TestAppComponents { this: Suite =>
  * to funny things like failure to enqueue events on the Akka scheduler timer due to the timer having
  * been shut down before it has ever been used.
  */
-trait PlayServerSupport extends SuiteMixin with TestAppComponents { this: Suite =>
+trait PlayServerSupport extends SuiteMixin with TestAppComponents with RequiresDB { this: Suite =>
 
   /**
    * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -113,6 +114,7 @@ trait PlayServerSupport extends SuiteMixin with TestAppComponents { this: Suite 
    * Invokes `start` on a new `TestServer` created with the `FakeApplication` provided by `app` and the
    * port number defined by `port`, places the `FakeApplication` and port number into the `ConfigMap` under the keys
    * `org.scalatestplus.play.app` and `org.scalatestplus.play.port`, respectively, to make
+   *
    * them available to nested suites; calls `super.run`; and lastly ensures the `FakeApplication and test server are stopped after
    * all tests and nested suites have completed.
    *
@@ -138,7 +140,12 @@ trait PlayServerSupport extends SuiteMixin with TestAppComponents { this: Suite 
   }
 }
 
-trait OneDIBrowserPerSuite extends SuiteMixin with WebBrowser with Eventually with IntegrationPatience with BrowserFactory { this: Suite =>
+trait OneDIBrowserPerSuite
+    extends SuiteMixin
+    with WebBrowser
+    with Eventually
+    with IntegrationPatience
+    with BrowserFactory { this: Suite =>
 
   /**
    * Override this to your needs

--- a/test/com/m3/octoparts/support/db/DBSuite.scala
+++ b/test/com/m3/octoparts/support/db/DBSuite.scala
@@ -1,5 +1,6 @@
 package com.m3.octoparts.support.db
 
+import com.m3.octoparts.support.PlayAppSupport
 import org.scalatest.{ Status, Args, BeforeAndAfterAll, fixture }
 
 /**
@@ -10,7 +11,7 @@ import org.scalatest.{ Status, Args, BeforeAndAfterAll, fixture }
  * Ensures that the test database is torn down and migrated to start with.
  * Each test "fixture" is wrapped in a transaction
  */
-trait DBSuite extends AutoRollback2 with BeforeAndAfterAll with RequiresDB { this: fixture.Suite =>
+trait DBSuite extends AutoRollback2 with BeforeAndAfterAll with PlayAppSupport { this: fixture.Suite =>
 
   override def beforeAll(): Unit = {
     tearDown()

--- a/test/com/m3/octoparts/support/db/RequiresDB.scala
+++ b/test/com/m3/octoparts/support/db/RequiresDB.scala
@@ -14,10 +14,12 @@ import scala.util.control.NonFatal
 /**
  * Trait to support tearing down and setting up the test DB.
  *
- * It extends OneAppPerSuite so that we use the Play app's Scalikejdbc connection pool,
- * thereby connecting to the correct DB (as configured in application.test.conf).
+ * Currently private to the [support] package because assumes that it is mixed into a test suite
+ * that ensures an app will be lazily set up so the stateful ConnectionPool singleton is initalised.
+ *
+ *
  */
-trait RequiresDB extends Suite {
+private[support] trait RequiresDB extends Suite {
 
   lazy val flyway = {
     val flyway = new Flyway

--- a/test/controllers/AdminControllerSpec.scala
+++ b/test/controllers/AdminControllerSpec.scala
@@ -107,7 +107,6 @@ class AdminControllerCompanionSpec extends FunSpec with Matchers with ConfigData
 class AdminControllerSpec
     extends FutureFunSpec
     with ConfigDataMocks
-    with RequiresDB
     with PlayAppSupport {
 
   implicit val emptySpan = new Span()

--- a/test/integration/AdminSpec.scala
+++ b/test/integration/AdminSpec.scala
@@ -11,7 +11,6 @@ class AdminSpec
     extends FunSpec
     with PlayServerSupport
     with OneDIBrowserPerSuite
-    with RequiresDB
     with HtmlUnitFactory
     with Matchers
     with ScalaFutures

--- a/test/integration/ApiSpec.scala
+++ b/test/integration/ApiSpec.scala
@@ -14,7 +14,6 @@ class ApiSpec
     extends FunSpec
     with PlayServerSupport
     with OneDIBrowserPerSuite
-    with RequiresDB
     with HtmlUnitFactory
     with Matchers
     with ScalaFutures


### PR DESCRIPTION
RequiresDB itself is now private to the test-time "support" package,
because it has an implicit dependency on being run in a test suite that
ensures there is a Play app running before its commands are run.
