### PR TITLE
Applying sbt-scalariform 1.6.0

### DIFF
--- a/app/com/m3/octoparts/aggregator/PartRequestInfo.scala
+++ b/app/com/m3/octoparts/aggregator/PartRequestInfo.scala
@@ -11,7 +11,8 @@ import com.m3.octoparts.model.{ PartRequest, RequestMeta }
 case class PartRequestInfo(
     requestMeta: RequestMeta,
     partRequest: PartRequest,
-    noCache: Boolean = false) {
+    noCache: Boolean = false
+) {
 
   val partRequestId = partRequest.id.getOrElse(partRequest.partId)
 

--- a/app/com/m3/octoparts/aggregator/handler/Handler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/Handler.scala
@@ -23,6 +23,9 @@ trait Handler {
   // Used primarily for creating a PartResponse, but also for logging purposes
   def partId: String
 
-  def process(partRequestInfo: PartRequestInfo, arguments: HandlerArguments)(implicit parentSpan: Span): Future[PartResponse]
+  def process(
+    partRequestInfo: PartRequestInfo,
+    arguments: HandlerArguments
+  )(implicit parentSpan: Span): Future[PartResponse]
 
 }

--- a/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/HttpPartRequestHandler.scala
@@ -21,8 +21,7 @@ import scala.util.matching.Regex
  * Trait describing a handler for processing of generic HTTP PartRequestInfo requests
  * that correspond to an external dependency
  */
-trait HttpPartRequestHandler extends Handler {
-  handler =>
+trait HttpPartRequestHandler extends Handler { self =>
 
   import HttpPartRequestHandler._
 
@@ -53,7 +52,10 @@ trait HttpPartRequestHandler extends Handler {
    * @param hArgs Preparsed HystrixArguments
    * @return Future[PartResponse]
    */
-  def process(partRequestInfo: PartRequestInfo, hArgs: HandlerArguments)(implicit parentSpan: Span): Future[PartResponse] = {
+  def process(
+    partRequestInfo: PartRequestInfo,
+    hArgs: HandlerArguments
+  )(implicit parentSpan: Span): Future[PartResponse] = {
     TracedFuture("Http request", "partId" -> partRequestInfo.partRequest.partId) { maybeSpan =>
       hystrixExecutor.future(
         createBlockingHttpRetrieve(partRequestInfo, hArgs, maybeSpan).retrieve(),
@@ -77,9 +79,13 @@ trait HttpPartRequestHandler extends Handler {
    * @param tracingSpan [[Span]] generated for tracing; the details of this will be forwarded as headers
    * @return a command object that will perform an HTTP request on demand
    */
-  def createBlockingHttpRetrieve(partRequestInfo: PartRequestInfo, hArgs: HandlerArguments, tracingSpan: Option[Span]): BlockingHttpRetrieve = {
+  def createBlockingHttpRetrieve(
+    partRequestInfo: PartRequestInfo,
+    hArgs: HandlerArguments,
+    tracingSpan: Option[Span]
+  ): BlockingHttpRetrieve = {
     new BlockingHttpRetrieve {
-      val httpClient = handler.httpClient
+      val httpClient = self.httpClient
       def method = httpMethod
       val uri = new URI(buildUri(hArgs).toString(UriConfig.conservative))
       val maybeBody = hArgs.collectFirst {

--- a/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
+++ b/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
@@ -8,7 +8,9 @@ import com.m3.octoparts.model.config.HttpPartConfig
 import scala.concurrent.ExecutionContext
 
 class SimpleHttpHandlerFactory(httpClientPool: HttpClientPool, implicit val zipkinService: ZipkinServiceLike)(
-    implicit executionContext: ExecutionContext) extends HttpHandlerFactory {
+    implicit
+    executionContext: ExecutionContext
+) extends HttpHandlerFactory {
 
   def makeHandler(config: HttpPartConfig) = {
     // Get or create the HTTP client corresponding to this partId

--- a/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
+++ b/app/com/m3/octoparts/aggregator/handler/SimpleHttpHandlerFactory.scala
@@ -7,10 +7,10 @@ import com.m3.octoparts.model.config.HttpPartConfig
 
 import scala.concurrent.ExecutionContext
 
-class SimpleHttpHandlerFactory(httpClientPool: HttpClientPool, implicit val zipkinService: ZipkinServiceLike)(
-    implicit
-    executionContext: ExecutionContext
-) extends HttpHandlerFactory {
+class SimpleHttpHandlerFactory(
+    httpClientPool: HttpClientPool,
+    implicit val zipkinService: ZipkinServiceLike
+)(implicit executionContext: ExecutionContext) extends HttpHandlerFactory {
 
   def makeHandler(config: HttpPartConfig) = {
     // Get or create the HTTP client corresponding to this partId

--- a/app/com/m3/octoparts/aggregator/handler/SimpleHttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/SimpleHttpPartRequestHandler.scala
@@ -22,5 +22,7 @@ class SimpleHttpPartRequestHandler(
   val httpMethod: HttpMethod.Value,
   val additionalValidStatuses: SortedSet[Int],
   val hystrixExecutor: HystrixExecutor
-)(implicit val executionContext: ExecutionContext, implicit val zipkinService: ZipkinServiceLike)
+)(implicit
+  val executionContext: ExecutionContext,
+  val zipkinService: ZipkinServiceLike)
     extends HttpPartRequestHandler

--- a/app/com/m3/octoparts/aggregator/handler/SimpleHttpPartRequestHandler.scala
+++ b/app/com/m3/octoparts/aggregator/handler/SimpleHttpPartRequestHandler.scala
@@ -21,5 +21,6 @@ class SimpleHttpPartRequestHandler(
   val uriToInterpolate: String,
   val httpMethod: HttpMethod.Value,
   val additionalValidStatuses: SortedSet[Int],
-  val hystrixExecutor: HystrixExecutor)(implicit val executionContext: ExecutionContext, implicit val zipkinService: ZipkinServiceLike)
+  val hystrixExecutor: HystrixExecutor
+)(implicit val executionContext: ExecutionContext, implicit val zipkinService: ZipkinServiceLike)
     extends HttpPartRequestHandler

--- a/app/com/m3/octoparts/aggregator/service/PartRequestService.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartRequestService.scala
@@ -12,5 +12,6 @@ import scala.concurrent.ExecutionContext
 class PartRequestService(
   val repository: ConfigsRepository,
   val handlerFactory: HttpHandlerFactory,
-  implicit val zipkinService: ZipkinServiceLike)(implicit val executionContext: ExecutionContext)
+  implicit val zipkinService: ZipkinServiceLike
+)(implicit val executionContext: ExecutionContext)
     extends PartRequestServiceBase

--- a/app/com/m3/octoparts/aggregator/service/PartRequestServiceBase.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartRequestServiceBase.scala
@@ -53,8 +53,18 @@ trait PartRequestServiceBase extends RequestParamSupport {
    */
   private def unsupported(pReq: PartRequestInfo): Future[PartResponse] = {
     val partId = pReq.partRequest.partId
-    LTSVLogger.warn("Request Id" -> pReq.requestMeta.id, "Requested PartId" -> partId, "Error" -> "not found")
-    Future.successful(PartResponse(partId, pReq.partRequestId, errors = Seq(unsupportedMsg(partId))))
+    LTSVLogger.warn(
+      "Request Id" -> pReq.requestMeta.id,
+      "Requested PartId" -> partId,
+      "Error" -> "not found"
+    )
+    Future.successful(
+      PartResponse(
+        partId,
+        pReq.partRequestId,
+        errors = Seq(unsupportedMsg(partId))
+      )
+    )
   }
 
   private[service] def unsupportedMsg(partId: String) = s"PartId $partId is unsupported"
@@ -83,7 +93,11 @@ trait PartRequestServiceBase extends RequestParamSupport {
    *           trait, but may be used for decorator purposes in Stackable traits.
    * @return Future[PartResponse], which includes adding deprecation notices
    */
-  protected def processWithConfig(ci: HttpPartConfig, partRequestInfo: PartRequestInfo, params: Map[ShortPartParam, Seq[String]])(implicit parentSpan: Span): Future[PartResponse] = {
+  protected def processWithConfig(
+    ci: HttpPartConfig,
+    partRequestInfo: PartRequestInfo,
+    params: Map[ShortPartParam, Seq[String]]
+  )(implicit parentSpan: Span): Future[PartResponse] = {
     val handler = handlerFactory.makeHandler(ci)
     val fResp = handler.process(partRequestInfo, params)
     fResp.map {
@@ -93,10 +107,16 @@ trait PartRequestServiceBase extends RequestParamSupport {
     }
   }
 
-  private def handleDeprecation(ci: HttpPartConfig, resp: PartResponse): PartResponse = ci.deprecatedInFavourOf.collect {
+  private def handleDeprecation(
+    ci: HttpPartConfig,
+    resp: PartResponse
+  ): PartResponse = ci.deprecatedInFavourOf.collect {
     case newPartId if newPartId.length > 0 =>
       resp.copy(warnings = resp.warnings :+ deprecationMsg(ci.partId, newPartId))
   }.getOrElse(resp)
 
-  private[service] def deprecationMsg(oldPartId: String, newPartId: String) = s"Please use $newPartId instead of $oldPartId"
+  private[service] def deprecationMsg(
+    oldPartId: String,
+    newPartId: String
+  ) = s"Please use $newPartId instead of $oldPartId"
 }

--- a/app/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupport.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupport.scala
@@ -19,7 +19,8 @@ trait PartResponseLocalContentSupport extends PartRequestServiceBase {
       Future.successful(createPartResponse(ci, partRequestInfo))
     } else {
       super.processWithConfig(ci, partRequestInfo, params).map { pr =>
-        if (pr.statusCode.contains(Status.SERVICE_UNAVAILABLE) && ci.hystrixConfigItem.localContentsAsFallback) createPartResponse(ci, partRequestInfo)
+        if (pr.statusCode.contains(Status.SERVICE_UNAVAILABLE) &&
+          ci.hystrixConfigItem.localContentsAsFallback) createPartResponse(ci, partRequestInfo)
         else pr
       }
     }

--- a/app/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupport.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupport.scala
@@ -10,9 +10,11 @@ import scala.concurrent.Future
 
 trait PartResponseLocalContentSupport extends PartRequestServiceBase {
 
-  override def processWithConfig(ci: HttpPartConfig,
-                                 partRequestInfo: PartRequestInfo,
-                                 params: Map[ShortPartParam, Seq[String]])(implicit parentSpan: Span): Future[PartResponse] = {
+  override def processWithConfig(
+    ci: HttpPartConfig,
+    partRequestInfo: PartRequestInfo,
+    params: Map[ShortPartParam, Seq[String]]
+  )(implicit parentSpan: Span): Future[PartResponse] = {
     if (ci.localContentsEnabled) {
       Future.successful(createPartResponse(ci, partRequestInfo))
     } else {
@@ -23,8 +25,10 @@ trait PartResponseLocalContentSupport extends PartRequestServiceBase {
     }
   }
 
-  private def createPartResponse(ci: HttpPartConfig,
-                                 partRequestInfo: PartRequestInfo) = PartResponse(
+  private def createPartResponse(
+    ci: HttpPartConfig,
+    partRequestInfo: PartRequestInfo
+  ) = PartResponse(
     ci.partId,
     id = partRequestInfo.partRequestId,
     statusCode = Some(Status.NON_AUTHORITATIVE_INFORMATION),

--- a/app/com/m3/octoparts/aggregator/service/PartServiceErrorHandler.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartServiceErrorHandler.scala
@@ -22,58 +22,125 @@ trait PartServiceErrorHandler extends LogUtil {
 
   def partRequestLogger: PartRequestLogger
 
-  private def logRejection(partRequestInfo: PartRequestInfo, aReqTimeout: Duration, message: String): PartResponse = {
+  private def logRejection(
+    partRequestInfo: PartRequestInfo,
+    aReqTimeout: Duration,
+    message: String
+  ): PartResponse = {
     val partId = partRequestInfo.partRequest.partId
     val requestMeta = partRequestInfo.requestMeta
-    LTSVLogger.warn("Part" -> partId, "Execution rejected" -> message)
+    LTSVLogger.warn(
+      "Part" -> partId,
+      "Execution rejected" -> message
+    )
     partRequestLogger.logTimeout(partId, requestMeta.id, requestMeta.serviceId, aReqTimeout.toMillis)
-    PartResponse(partId, partRequestInfo.partRequestId, errors = Seq(message))
+    PartResponse(
+      partId,
+      partRequestInfo.partRequestId,
+      errors = Seq(message)
+    )
   }
 
-  private def logTimeout(partRequestInfo: PartRequestInfo, aReqTimeout: Duration, message: String): PartResponse = {
+  private def logTimeout(
+    partRequestInfo: PartRequestInfo,
+    aReqTimeout: Duration,
+    message: String
+  ): PartResponse = {
     val partId = partRequestInfo.partRequest.partId
     val requestMeta = partRequestInfo.requestMeta
-    LTSVLogger.warn("Part" -> partId, "Timed out" -> aReqTimeout.toString)
+    LTSVLogger.warn(
+      "Part" -> partId,
+      "Timed out" -> aReqTimeout.toString
+    )
     partRequestLogger.logTimeout(partId, requestMeta.id, requestMeta.serviceId, aReqTimeout.toMillis)
-    PartResponse(partId, partRequestInfo.partRequestId, errors = Seq(message))
+    PartResponse(
+      partId,
+      partRequestInfo.partRequestId,
+      errors = Seq(message)
+    )
   }
 
-  private def logInvalid(partRequestInfo: PartRequestInfo, message: String): PartResponse = {
+  private def logInvalid(
+    partRequestInfo: PartRequestInfo,
+    message: String
+  ): PartResponse = {
     val partId = partRequestInfo.partRequest.partId
     val requestMeta = partRequestInfo.requestMeta
-    LTSVLogger.warn("Part" -> partId, "Invalid" -> message)
+    LTSVLogger.warn(
+      "Part" -> partId,
+      "Invalid" -> message
+    )
     partRequestLogger.logFailure(partId, requestMeta.id, requestMeta.serviceId, statusCode = None)
-    PartResponse(partId, partRequestInfo.partRequestId, errors = Seq(message))
+    PartResponse(
+      partId,
+      partRequestInfo.partRequestId,
+      errors = Seq(message)
+    )
   }
 
-  private def logShortCircuit(partRequestInfo: PartRequestInfo, message: String): PartResponse = {
+  private def logShortCircuit(
+    partRequestInfo: PartRequestInfo,
+    message: String
+  ): PartResponse = {
     val partId = partRequestInfo.partRequest.partId
     val requestMeta = partRequestInfo.requestMeta
-    LTSVLogger.warn("Part" -> partId, "Hystrix" -> message)
+    LTSVLogger.warn(
+      "Part" -> partId,
+      "Hystrix" -> message
+    )
     partRequestLogger.logFailure(partId, requestMeta.id, requestMeta.serviceId, statusCode = None)
-    PartResponse(partId, partRequestInfo.partRequestId, errors = Seq(message))
+    PartResponse(
+      partId,
+      partRequestInfo.partRequestId,
+      errors = Seq(message)
+    )
   }
 
-  private def logIOException(partRequestInfo: PartRequestInfo, io: Throwable) = {
+  private def logIOException(
+    partRequestInfo: PartRequestInfo,
+    io: IOException
+  ) = {
     val partId = partRequestInfo.partRequest.partId
     val requestMeta = partRequestInfo.requestMeta
-    LTSVLogger.warn(io, "Part" -> partId)
+    LTSVLogger.warn(
+      io,
+      "Part" -> partId
+    )
     partRequestLogger.logFailure(partId, requestMeta.id, requestMeta.serviceId, statusCode = None)
-    PartResponse(partId, partRequestInfo.partRequestId, errors = Seq(io.toString))
+    PartResponse(
+      partId,
+      partRequestInfo.partRequestId,
+      errors = Seq(io.toString)
+    )
   }
 
-  private def logOtherException(partRequestInfo: PartRequestInfo, err: Throwable) = {
+  private def logOtherException(
+    partRequestInfo: PartRequestInfo,
+    err: Throwable
+  ) = {
     val partId = partRequestInfo.partRequest.partId
     val requestMeta = partRequestInfo.requestMeta
-    LTSVLogger.error(err, "Part" -> partId)
+    LTSVLogger.error(
+      err,
+      "Part" -> partId
+    )
     partRequestLogger.logFailure(partId, requestMeta.id, requestMeta.serviceId, statusCode = None)
-    PartResponse(partId, partRequestInfo.partRequestId, errors = Seq(err.toString))
+    PartResponse(
+      partId,
+      partRequestInfo.partRequestId,
+      errors = Seq(err.toString)
+    )
   }
 
-  protected def recoverChain(partRequestInfo: PartRequestInfo, aReqTimeout: Duration, f: Future[PartResponse]): Future[PartResponse] = {
+  protected def recoverChain(
+    partRequestInfo: PartRequestInfo,
+    aReqTimeout: Duration,
+    f: Future[PartResponse]
+  ): Future[PartResponse] = {
     f.recoverWith {
       // unpile command exception
-      case hre: HystrixRuntimeException if Option(hre.getCause).exists(_ != hre) && hre.getFailureType == FailureType.COMMAND_EXCEPTION =>
+      case hre: HystrixRuntimeException if Option(hre.getCause).exists(_ != hre)
+        && hre.getFailureType == FailureType.COMMAND_EXCEPTION =>
         Future.failed(hre.getCause)
 
     }.recover {

--- a/app/com/m3/octoparts/aggregator/service/PartsService.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartsService.scala
@@ -20,7 +20,8 @@ class PartsService(
   val partRequestLogger: PartRequestLogger = PartRequestLogger,
   maximumAggReqTimeout: FiniteDuration = 5.seconds
 )(implicit val executionContext: ExecutionContext)
-    extends PartServiceErrorHandler with LogUtil {
+    extends PartServiceErrorHandler
+    with LogUtil {
 
   import com.m3.octoparts.logging.LTSVables._
 
@@ -38,7 +39,10 @@ class PartsService(
    * @param aggregateRequest AggregateRequest
    * @return Future[AggregateResponse]
    */
-  def processParts(aggregateRequest: AggregateRequest, noCache: Boolean = false)(implicit parentSpan: Span): Future[AggregateResponse] = {
+  def processParts(
+    aggregateRequest: AggregateRequest,
+    noCache: Boolean = false
+  )(implicit parentSpan: Span): Future[AggregateResponse] = {
     val requestMeta = aggregateRequest.requestMeta
     val aReqTimeout: FiniteDuration = requestMeta.timeout.getOrElse(maximumAggReqTimeout) min maximumAggReqTimeout
     val partsResponsesFutures = aggregateRequest.requests.map {
@@ -69,7 +73,11 @@ class PartsService(
     }
   }
 
-  private def logPartResponse(requestMeta: RequestMeta, partResponse: PartResponse, responseMs: Long): Unit = partResponse match {
+  private def logPartResponse(
+    requestMeta: RequestMeta,
+    partResponse: PartResponse,
+    responseMs: Long
+  ): Unit = partResponse match {
     case pResp if pResp.errors.nonEmpty => partRequestLogger.logFailure(pResp.partId, requestMeta.id, requestMeta.serviceId, pResp.statusCode)
     case pResp if pResp.retrievedFromCache => partRequestLogger.logSuccess(pResp.partId, requestMeta.id, requestMeta.serviceId, cacheHit = true, responseMs)
     case pResp => partRequestLogger.logSuccess(pResp.partId, requestMeta.id, requestMeta.serviceId, cacheHit = false, responseMs)

--- a/app/com/m3/octoparts/aggregator/service/PartsService.scala
+++ b/app/com/m3/octoparts/aggregator/service/PartsService.scala
@@ -15,9 +15,11 @@ import scala.language.postfixOps
 /**
  * Service that has a #processParts method that returns a Future[AggregateResponse]
  */
-class PartsService(partRequestService: PartRequestServiceBase,
-                   val partRequestLogger: PartRequestLogger = PartRequestLogger,
-                   maximumAggReqTimeout: FiniteDuration = 5.seconds)(implicit val executionContext: ExecutionContext)
+class PartsService(
+  partRequestService: PartRequestServiceBase,
+  val partRequestLogger: PartRequestLogger = PartRequestLogger,
+  maximumAggReqTimeout: FiniteDuration = 5.seconds
+)(implicit val executionContext: ExecutionContext)
     extends PartServiceErrorHandler with LogUtil {
 
   import com.m3.octoparts.logging.LTSVables._

--- a/app/com/m3/octoparts/aggregator/service/RequestParamSupport.scala
+++ b/app/com/m3/octoparts/aggregator/service/RequestParamSupport.scala
@@ -23,7 +23,10 @@ trait RequestParamSupport {
    *
    * @param partRequestInfo Part request info
    */
-  def combineParams(registeredParams: SortedSet[PartParam], partRequestInfo: PartRequestInfo): Map[ShortPartParam, Seq[String]] = {
+  def combineParams(
+    registeredParams: SortedSet[PartParam],
+    partRequestInfo: PartRequestInfo
+  ): Map[ShortPartParam, Seq[String]] = {
     val combinedParams = {
       val allParams = processMeta(partRequestInfo.requestMeta) ++ partRequestInfo.partRequest.params
       allParams.groupBy(_.key).mapValues(_.map(_.value))
@@ -46,7 +49,10 @@ trait RequestParamSupport {
     }).toMap
   }
 
-  private[service] def validateParams(registeredParams: Set[PartParam], mappedParams: Set[PartParam]): Unit = {
+  private[service] def validateParams(
+    registeredParams: Set[PartParam],
+    mappedParams: Set[PartParam]
+  ): Unit = {
     val missingRequiredParams = (registeredParams -- mappedParams).filter(_.required)
     if (missingRequiredParams.nonEmpty) {
       val missingParamsAsString = missingRequiredParams.map(_.inputName).mkString(", ")

--- a/app/com/m3/octoparts/cache/Cache.scala
+++ b/app/com/m3/octoparts/cache/Cache.scala
@@ -16,8 +16,16 @@ trait Cache {
 
   // TODO shade dependency decoupling
 
-  def get[T](key: CacheKey)(implicit codec: Codec[T], parentSpan: Span): Future[Option[T]]
+  def get[T](
+    key: CacheKey
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Option[T]]
 
-  def put[T](key: CacheKey, v: T, ttl: Option[Duration])(implicit codec: Codec[T], parentSpan: Span): Future[Unit]
+  def put[T](
+    key: CacheKey,
+    v: T,
+    ttl: Option[Duration]
+  )(implicit codec: Codec[T], parentSpan: Span): Future[Unit]
 
 }

--- a/app/com/m3/octoparts/cache/CacheException.scala
+++ b/app/com/m3/octoparts/cache/CacheException.scala
@@ -2,4 +2,7 @@ package com.m3.octoparts.cache
 
 import com.m3.octoparts.cache.key.CacheKey
 
-case class CacheException(key: CacheKey, cause: Throwable) extends Exception(cause)
+case class CacheException(
+  key: CacheKey,
+  cause: Throwable
+) extends Exception(cause)

--- a/app/com/m3/octoparts/cache/CacheOps.scala
+++ b/app/com/m3/octoparts/cache/CacheOps.scala
@@ -32,11 +32,15 @@ trait CacheOps {
    * @param f block to generate a value if one is not found in the cache
    * @return a Future of the value
    */
-  def putIfAbsent(directive: CacheDirective)(f: => Future[PartResponse])(implicit parentSpan: Span): Future[PartResponse]
+  def putIfAbsent(directive: CacheDirective)(
+    f: => Future[PartResponse]
+  )(implicit parentSpan: Span): Future[PartResponse]
 
   /**
    * Unconditional PUT of a PartResponse
    */
-  def saveLater(partResponse: PartResponse, directive: CacheDirective)(implicit parentSpan: Span): Future[Unit]
+  def saveLater(
+    partResponse: PartResponse,
+    directive: CacheDirective
+  )(implicit parentSpan: Span): Future[Unit]
 }
-

--- a/app/com/m3/octoparts/cache/LoggingRawCache.scala
+++ b/app/com/m3/octoparts/cache/LoggingRawCache.scala
@@ -11,20 +11,44 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
  * A decorator to add debug logging to a [[RawCache]]
  */
-class LoggingRawCache(delegate: RawCache)(implicit executionContext: ExecutionContext) extends RawCache with LogUtil {
+class LoggingRawCache(
+  delegate: RawCache
+)(implicit executionContext: ExecutionContext)
+    extends RawCache
+    with LogUtil {
 
-  def get[T](key: String)(implicit codec: Codec[T], parentSpan: Span): Future[Option[T]] = {
+  def get[T](
+    key: String
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Option[T]] = {
     val f = delegate.get(key)(codec, parentSpan)
     f.onSuccess {
-      case mbVal => LTSVLogger.debug("Memcached" -> "get", "key" -> key, "is" -> truncateValue(mbVal))
+      case mbVal => LTSVLogger.debug(
+        "Memcached" -> "get",
+        "key" -> key,
+        "is" -> truncateValue(mbVal)
+      )
     }
     f
   }
 
-  def set[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T], parentSpan: Span): Future[Unit] = {
+  def set[T](
+    key: String,
+    value: T,
+    exp: Duration
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Unit] = {
     val f = delegate.set(key, value, exp)(codec, parentSpan)
     f.onSuccess {
-      case done => LTSVLogger.debug("Memcached" -> "set", "key" -> key, "value" -> truncateValue(value), "duration" -> exp.toString)
+      case done =>
+        LTSVLogger.debug(
+          "Memcached" -> "set",
+          "key" -> key,
+          "value" -> truncateValue(value),
+          "duration" -> exp.toString
+        )
     }
     f
   }

--- a/app/com/m3/octoparts/cache/MemoryBufferingRawCache.scala
+++ b/app/com/m3/octoparts/cache/MemoryBufferingRawCache.scala
@@ -19,16 +19,26 @@ import scala.concurrent.{ ExecutionContext, Future }
  *                           - receptiveness to external changes (in case the network cache is shared)
  *
  */
-class MemoryBufferingRawCache(networkCache: RawCache, localCacheDuration: Duration) extends RawCache {
+class MemoryBufferingRawCache(
+    networkCache: RawCache,
+    localCacheDuration: Duration
+) extends RawCache {
 
-  protected val memoryCache: GuavaCache[String, Object] = configureMemoryCache(CacheBuilder.newBuilder()).build[String, Object]()
+  protected val memoryCache: GuavaCache[String, Object] =
+    configureMemoryCache(CacheBuilder.newBuilder()).build[String, Object]()
 
   // exposed for testing
-  protected def configureMemoryCache(builder: CacheBuilder[Object, Object]): CacheBuilder[Object, Object] = {
+  protected def configureMemoryCache(
+    builder: CacheBuilder[Object, Object]
+  ): CacheBuilder[Object, Object] = {
     builder.expireAfterWrite(localCacheDuration.toMillis, TimeUnit.MILLISECONDS)
   }
 
-  def set[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T], parentSpan: Span): Future[Unit] = {
+  def set[T](
+    key: String,
+    value: T,
+    exp: Duration
+  )(implicit codec: Codec[T], parentSpan: Span): Future[Unit] = {
     if (exp >= localCacheDuration) {
       storeInMemoryCache(key, value)
     } else {
@@ -60,10 +70,17 @@ class MemoryBufferingRawCache(networkCache: RawCache, localCacheDuration: Durati
     networkCache.close()
   }
 
-  protected def storeInMemoryCache(key: String, value: Any): Unit = value match {
+  protected def storeInMemoryCache(
+    key: String,
+    value: Any
+  ): Unit = value match {
     case obj: Object => {
       memoryCache.put(key, obj)
-      LTSVLogger.trace("Key set in local cache" -> key, "to" -> obj.toString, "for" -> localCacheDuration.toString)
+      LTSVLogger.trace(
+        "Key set in local cache" -> key,
+        "to" -> obj.toString,
+        "for" -> localCacheDuration.toString
+      )
     }
     case _ =>
   }

--- a/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
+++ b/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
@@ -19,7 +19,10 @@ private[cache] object PartResponseCachingSupport {
   /**
    * @return The response to use (between the cached one and the new one). Will use new one <=> the new one is not a 304.
    */
-  private[cache] def selectLatest(newPartResponse: PartResponse, existingPartResponse: PartResponse): PartResponse = {
+  private[cache] def selectLatest(
+    newPartResponse: PartResponse,
+    existingPartResponse: PartResponse
+  ): PartResponse = {
     val is304 = newPartResponse.statusCode.fold(false) {
       _.intValue == HttpStatus.SC_NOT_MODIFIED
     }
@@ -50,19 +53,27 @@ trait PartResponseCachingSupport extends PartRequestServiceBase {
       val futureMaybeFromCache =
         cacheOps.putIfAbsent(directive)(super.processWithConfig(ci, partRequestInfo, params))
           .recoverWith(onCacheFailure(ci, partRequestInfo, params))
-          .trace("retrieve-part-response-from-cache-or-else", "partId" -> ci.partId)
-      futureMaybeFromCache.flatMap {
-        partResponse =>
-          // at this point, the response may come from cache and be stale.
+          .trace(
+            "retrieve-part-response-from-cache-or-else",
+            "partId" -> ci.partId
+          )
+      futureMaybeFromCache
+        // at this point, the response may come from cache and be stale.
+        .flatMap { partResponse =>
           if (shouldRevalidate(partResponse)) {
-            revalidate(partResponse, directive, ci, partRequestInfo, params).trace("part-response-cache-revalidation")
+            revalidate(
+              partResponse,
+              directive,
+              ci,
+              partRequestInfo,
+              params
+            ).trace("part-response-cache-revalidation")
           } else {
             Future.successful(partResponse)
           }
-      }.map {
+        }
         // Replace the ID with the one specified in the current request
-        partResponse => partResponse.copy(id = partRequestInfo.partRequestId)
-      }
+        .map { partResponse => partResponse.copy(id = partRequestInfo.partRequestId) }
     }
   }
 
@@ -74,9 +85,16 @@ trait PartResponseCachingSupport extends PartRequestServiceBase {
     case ce: CacheException => {
       ce.getCause match {
         case te: shade.TimeoutException =>
-          LTSVLogger.warn("Memcached error" -> "timed out", "cache key" -> ce.key.toString)
+          LTSVLogger.warn(
+            "Memcached error" -> "timed out",
+            "cache key" -> ce.key.toString
+          )
         case other =>
-          LTSVLogger.error(other, "Memcached error" -> other.getClass.getSimpleName, "cache key" -> ce.key.toString)
+          LTSVLogger.error(
+            other,
+            "Memcached error" -> other.getClass.getSimpleName,
+            "cache key" -> ce.key.toString
+          )
       }
       super.processWithConfig(ci, partRequestInfo, params)
     }

--- a/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
+++ b/app/com/m3/octoparts/cache/PartResponseCachingSupport.scala
@@ -36,9 +36,11 @@ trait PartResponseCachingSupport extends PartRequestServiceBase {
   import com.beachape.zipkin.FutureEnrichment._
   def cacheOps: CacheOps
 
-  override def processWithConfig(ci: HttpPartConfig,
-                                 partRequestInfo: PartRequestInfo,
-                                 params: Map[ShortPartParam, Seq[String]])(implicit parentSpan: Span): Future[PartResponse] = {
+  override def processWithConfig(
+    ci: HttpPartConfig,
+    partRequestInfo: PartRequestInfo,
+    params: Map[ShortPartParam, Seq[String]]
+  )(implicit parentSpan: Span): Future[PartResponse] = {
 
     if (partRequestInfo.noCache || !ci.cacheConfig.cachingEnabled) {
       // noCache or TTL defined but 0 => skip caching
@@ -64,9 +66,11 @@ trait PartResponseCachingSupport extends PartRequestServiceBase {
     }
   }
 
-  private def onCacheFailure(ci: HttpPartConfig,
-                             partRequestInfo: PartRequestInfo,
-                             params: Map[ShortPartParam, Seq[String]])(implicit parentSpan: Span): PartialFunction[Throwable, Future[PartResponse]] = {
+  private def onCacheFailure(
+    ci: HttpPartConfig,
+    partRequestInfo: PartRequestInfo,
+    params: Map[ShortPartParam, Seq[String]]
+  )(implicit parentSpan: Span): PartialFunction[Throwable, Future[PartResponse]] = {
     case ce: CacheException => {
       ce.getCause match {
         case te: shade.TimeoutException =>
@@ -86,11 +90,13 @@ trait PartResponseCachingSupport extends PartRequestServiceBase {
     }
   }
 
-  private[cache] def revalidate(partResponse: PartResponse,
-                                directive: CacheDirective,
-                                ci: HttpPartConfig,
-                                partRequestInfo: PartRequestInfo,
-                                params: Map[ShortPartParam, Seq[String]])(implicit parentSpan: Span): Future[PartResponse] = {
+  private[cache] def revalidate(
+    partResponse: PartResponse,
+    directive: CacheDirective,
+    ci: HttpPartConfig,
+    partRequestInfo: PartRequestInfo,
+    params: Map[ShortPartParam, Seq[String]]
+  )(implicit parentSpan: Span): Future[PartResponse] = {
 
     val revalidationParams = for {
       (name, value) <- partResponse.cacheControl.revalidationHeaders

--- a/app/com/m3/octoparts/cache/RawCache.scala
+++ b/app/com/m3/octoparts/cache/RawCache.scala
@@ -20,7 +20,8 @@ trait RawCache {
   /**
    * Fetches a value from the cache store.
    *
-   * @return Some(value) in case the key is available, or None otherwise (doesn't throw exception on key missing)
+   * @return Some(value) in case the key is available,
+   * * or None otherwise (doesn't throw exception on key missing)
    */
   def get[T](key: String)(implicit codec: Codec[T], parentSpan: Span): Future[Option[T]]
 
@@ -29,7 +30,11 @@ trait RawCache {
    *
    * The TTL can be Duration.Inf (infinite duration).
    */
-  def set[T](key: String, value: T, ttl: Duration)(implicit codec: Codec[T], parentSpan: Span): Future[Unit]
+  def set[T](
+    key: String,
+    value: T,
+    ttl: Duration
+  )(implicit codec: Codec[T], parentSpan: Span): Future[Unit]
 
   /**
    * Shutdown and clean up any resources.

--- a/app/com/m3/octoparts/cache/RichCacheControl.scala
+++ b/app/com/m3/octoparts/cache/RichCacheControl.scala
@@ -11,7 +11,9 @@ object RichCacheControl {
   /**
    * Enrich model cacheControl because we do not want joda or httpclient to be dependency of the exported models.
    */
-  implicit class RichCacheControlOps(val cacheControl: CacheControl) extends AnyVal {
+  implicit class RichCacheControlOps(
+      val cacheControl: CacheControl
+  ) extends AnyVal {
 
     def shouldRevalidate = cacheControl.noCache || (cacheControl.canRevalidate && hasExpired)
 
@@ -30,4 +32,3 @@ object RichCacheControl {
 
   }
 }
-

--- a/app/com/m3/octoparts/cache/config/CacheConfig.scala
+++ b/app/com/m3/octoparts/cache/config/CacheConfig.scala
@@ -7,8 +7,10 @@ import scala.concurrent.duration.Duration
  * This config can be combined with information about the parameters of an individual part request
  * in order to create a cache directive for the part request.
  */
-case class CacheConfig(ttl: Option[Duration] = None,
-                       versionedParams: Seq[String] = Nil) {
+case class CacheConfig(
+  ttl: Option[Duration] = None,
+    versionedParams: Seq[String] = Nil
+) {
   // caching is enabled if the TTL is not <= 0
   def cachingEnabled: Boolean = ttl.fold(true)(_.toSeconds > 0)
 }

--- a/app/com/m3/octoparts/cache/config/CacheConfig.scala
+++ b/app/com/m3/octoparts/cache/config/CacheConfig.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
  * in order to create a cache directive for the part request.
  */
 case class CacheConfig(
-  ttl: Option[Duration] = None,
+    ttl: Option[Duration] = None,
     versionedParams: Seq[String] = Nil
 ) {
   // caching is enabled if the TTL is not <= 0
@@ -18,4 +18,3 @@ case class CacheConfig(
 object CacheConfig {
   val NoCache = CacheConfig()
 }
-

--- a/app/com/m3/octoparts/cache/directive/CacheDirective.scala
+++ b/app/com/m3/octoparts/cache/directive/CacheDirective.scala
@@ -11,7 +11,9 @@ import scala.concurrent.duration.Duration
  * @param versionedParamKeys a list of parameters that are versioned
  * @param ttl Time To Live
  */
-case class CacheDirective(partId: String,
-                          versionedParamKeys: Seq[VersionedParamKey] = Nil,
-                          paramValues: Map[ShortPartParam, Seq[String]] = Map.empty,
-                          ttl: Option[Duration] = None)
+case class CacheDirective(
+  partId: String,
+  versionedParamKeys: Seq[VersionedParamKey] = Nil,
+  paramValues: Map[ShortPartParam, Seq[String]] = Map.empty,
+  ttl: Option[Duration] = None
+)

--- a/app/com/m3/octoparts/cache/directive/CacheDirectiveGenerator.scala
+++ b/app/com/m3/octoparts/cache/directive/CacheDirectiveGenerator.scala
@@ -9,9 +9,11 @@ trait CacheDirectiveGenerator {
   /**
    * Generate a cache directive, i.e. all the information the cache client needs to lookup/insert a PartResponse.
    */
-  def generateDirective(partId: String,
-                        params: Map[ShortPartParam, Seq[String]],
-                        cacheConfig: CacheConfig): CacheDirective
+  def generateDirective(
+    partId: String,
+    params: Map[ShortPartParam, Seq[String]],
+    cacheConfig: CacheConfig
+  ): CacheDirective
 }
 
 object CacheDirectiveGenerator extends CacheDirectiveGenerator {

--- a/app/com/m3/octoparts/cache/directive/CacheDirectiveGenerator.scala
+++ b/app/com/m3/octoparts/cache/directive/CacheDirectiveGenerator.scala
@@ -17,7 +17,11 @@ trait CacheDirectiveGenerator {
 }
 
 object CacheDirectiveGenerator extends CacheDirectiveGenerator {
-  def generateDirective(partId: String, params: Map[ShortPartParam, Seq[String]], cacheConfig: CacheConfig): CacheDirective = {
+  def generateDirective(
+    partId: String,
+    params: Map[ShortPartParam, Seq[String]],
+    cacheConfig: CacheConfig
+  ): CacheDirective = {
     // for version param keys, only single-value parameters are supported.
     val strParams = params.map {
       case (shortPartParam, values) =>

--- a/app/com/m3/octoparts/cache/dummy/DummyCache.scala
+++ b/app/com/m3/octoparts/cache/dummy/DummyCache.scala
@@ -10,8 +10,18 @@ import scala.concurrent.duration.Duration
 
 object DummyCache extends Cache {
 
-  def get[T](key: CacheKey)(implicit codec: Codec[T], parentSpan: Span): Future[Option[T]] = Future.successful(None)
+  def get[T](
+    key: CacheKey
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Option[T]] = Future.successful(None)
 
-  def put[T](key: CacheKey, v: T, ttl: Option[Duration])(implicit codec: Codec[T], parentSpan: Span): Future[Unit] = Future.successful(())
+  def put[T](
+    key: CacheKey,
+    v: T,
+    ttl: Option[Duration]
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Unit] = Future.successful(())
 
 }

--- a/app/com/m3/octoparts/cache/dummy/DummyCacheOps.scala
+++ b/app/com/m3/octoparts/cache/dummy/DummyCacheOps.scala
@@ -9,11 +9,15 @@ import com.twitter.zipkin.gen.Span
 import scala.concurrent.Future
 
 object DummyCacheOps extends CacheOps {
+
   override def increasePartVersion(partId: String)(implicit parentSpan: Span) = Future.successful(())
 
   override def putIfAbsent(directive: CacheDirective)(f: => Future[PartResponse])(implicit parentSpan: Span) = f
 
   override def increaseParamVersion(vpk: VersionedParamKey)(implicit parentSpan: Span) = Future.successful(())
 
-  override def saveLater(partResponse: PartResponse, directive: CacheDirective)(implicit parentSpan: Span) = Future.successful(())
+  override def saveLater(
+    partResponse: PartResponse,
+    directive: CacheDirective
+  )(implicit parentSpan: Span) = Future.successful(())
 }

--- a/app/com/m3/octoparts/cache/dummy/DummyLatestVersionCache.scala
+++ b/app/com/m3/octoparts/cache/dummy/DummyLatestVersionCache.scala
@@ -4,6 +4,7 @@ import com.m3.octoparts.cache.versioning.LatestVersionCache.{ PartId, Version }
 import com.m3.octoparts.cache.versioning.{ LatestVersionCache, VersionedParamKey }
 
 object DummyLatestVersionCache extends LatestVersionCache {
+
   override def getPartVersion(partId: PartId) = None
 
   /**
@@ -16,5 +17,8 @@ object DummyLatestVersionCache extends LatestVersionCache {
   /**
    * Update the latest known cache version for a given param value
    */
-  override def updateParamVersion(versionedParamKey: VersionedParamKey, version: Version) = {}
+  override def updateParamVersion(
+    versionedParamKey: VersionedParamKey,
+    version: Version
+  ) = {}
 }

--- a/app/com/m3/octoparts/cache/dummy/DummyRawCache.scala
+++ b/app/com/m3/octoparts/cache/dummy/DummyRawCache.scala
@@ -9,9 +9,19 @@ import scala.concurrent.duration.Duration
 
 object DummyRawCache extends RawCache {
 
-  def get[T](key: String)(implicit codec: Codec[T], parentSpan: Span): Future[Option[T]] = Future.successful(None)
+  def get[T](
+    key: String
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Option[T]] = Future.successful(None)
 
-  def set[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T], parentSpan: Span): Future[Unit] = Future.successful(())
+  def set[T](
+    key: String,
+    value: T,
+    exp: Duration
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Unit] = Future.successful(())
 
   def close(): Unit = {}
 

--- a/app/com/m3/octoparts/cache/key/CacheGroupCacheKey.scala
+++ b/app/com/m3/octoparts/cache/key/CacheGroupCacheKey.scala
@@ -1,3 +1,5 @@
 package com.m3.octoparts.cache.key
 
-case class CacheGroupCacheKey[T <: java.io.Serializable](id: T) extends CacheKey
+case class CacheGroupCacheKey[T <: java.io.Serializable](
+  id: T
+) extends CacheKey

--- a/app/com/m3/octoparts/cache/key/CacheKey.scala
+++ b/app/com/m3/octoparts/cache/key/CacheKey.scala
@@ -2,8 +2,6 @@ package com.m3.octoparts.cache.key
 
 /**
  * A key that can be used to lookup a value in a cache.
+ * this is all we ask for a CacheKey. Implementations are client-specific.
  */
-
-// this is all we ask for a CacheKey. Implementations are client-specific.
 trait CacheKey extends Serializable
-

--- a/app/com/m3/octoparts/cache/key/HttpPartConfigCacheKey.scala
+++ b/app/com/m3/octoparts/cache/key/HttpPartConfigCacheKey.scala
@@ -4,4 +4,6 @@ package com.m3.octoparts.cache.key
  * We should use different case classes for each kind of object we want to through
  * into the cache because it allows us to ensure that each key generated is unique
  */
-case class HttpPartConfigCacheKey[T <: java.io.Serializable](id: T) extends CacheKey
+case class HttpPartConfigCacheKey[T <: java.io.Serializable](
+  id: T
+) extends CacheKey

--- a/app/com/m3/octoparts/cache/key/PartCacheKey.scala
+++ b/app/com/m3/octoparts/cache/key/PartCacheKey.scala
@@ -6,5 +6,6 @@ import com.m3.octoparts.model.config.ShortPartParam
 case class PartCacheKey(
   partId: String,
   versions: Seq[Version],
-  paramValues: Map[ShortPartParam, Seq[String]])
+  paramValues: Map[ShortPartParam, Seq[String]]
+)
     extends CacheKey

--- a/app/com/m3/octoparts/cache/key/PartCacheKey.scala
+++ b/app/com/m3/octoparts/cache/key/PartCacheKey.scala
@@ -7,5 +7,4 @@ case class PartCacheKey(
   partId: String,
   versions: Seq[Version],
   paramValues: Map[ShortPartParam, Seq[String]]
-)
-    extends CacheKey
+) extends CacheKey

--- a/app/com/m3/octoparts/cache/key/VersionCacheKey.scala
+++ b/app/com/m3/octoparts/cache/key/VersionCacheKey.scala
@@ -1,3 +1,5 @@
 package com.m3.octoparts.cache.key
 
-case class VersionCacheKey[T <: java.io.Serializable](id: T) extends CacheKey
+case class VersionCacheKey[T <: java.io.Serializable](
+  id: T
+) extends CacheKey

--- a/app/com/m3/octoparts/cache/memcached/InMemoryRawCache.scala
+++ b/app/com/m3/octoparts/cache/memcached/InMemoryRawCache.scala
@@ -12,17 +12,27 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
  * An in-memory cache that can be used as a drop-in replacement for Memcached
  */
-class InMemoryRawCache(zipkinServiceFactory: => ZipkinServiceLike)(implicit executionContext: ExecutionContext) extends RawCache {
+class InMemoryRawCache(
+    zipkinServiceFactory: => ZipkinServiceLike
+)(implicit executionContext: ExecutionContext) extends RawCache {
 
   lazy implicit val zipkinService = zipkinServiceFactory
 
   private val impl = ShadeInMemoryCache(executionContext)
 
-  def get[T](key: String)(implicit codec: Codec[T], parentSpan: Span): Future[Option[T]] = Future {
+  def get[T](
+    key: String
+  )(implicit
+    codec: Codec[T],
+    parentSpan: Span): Future[Option[T]] = Future {
     impl.get(key)
   }
 
-  def set[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T], parentSpan: Span): Future[Unit] = Future {
+  def set[T](
+    key: String,
+    value: T,
+    exp: Duration
+  )(implicit codec: Codec[T], parentSpan: Span): Future[Unit] = Future {
     impl.set(key, value, exp)
   }
 

--- a/app/com/m3/octoparts/cache/memcached/MemcachedCacheOps.scala
+++ b/app/com/m3/octoparts/cache/memcached/MemcachedCacheOps.scala
@@ -13,7 +13,8 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 class MemcachedCacheOps(
   cache: Cache,
-  latestVersionCache: LatestVersionCache)(implicit executionContext: ExecutionContext)
+  latestVersionCache: LatestVersionCache
+)(implicit executionContext: ExecutionContext)
     extends CacheOps
     with TtlCalculator {
 
@@ -62,7 +63,8 @@ class MemcachedCacheOps(
   }
 
   case class CombinedVersionLookup(
-      partVersionLookup: VersionLookup[String], paramVersionLookups: Seq[VersionLookup[VersionedParamKey]])(implicit parentSpan: Span) {
+      partVersionLookup: VersionLookup[String], paramVersionLookups: Seq[VersionLookup[VersionedParamKey]]
+  )(implicit parentSpan: Span) {
 
     lazy val all: Seq[VersionLookup[_]] = partVersionLookup +: paramVersionLookups
 
@@ -169,7 +171,8 @@ class MemcachedCacheOps(
 
   // assumes hashes do not collide : only versions are verified
   private def checkAndReturn(
-    directive: CacheDirective, resp: PartResponse, versionLookups: CombinedVersionLookup)(implicit parentSpan: Span): Future[Option[PartResponse]] = {
+    directive: CacheDirective, resp: PartResponse, versionLookups: CombinedVersionLookup
+  )(implicit parentSpan: Span): Future[Option[PartResponse]] = {
     // really basic check to make sure we return a valid entry
     // e.g. has the right partId
     if (resp.partId == versionLookups.partId) {

--- a/app/com/m3/octoparts/cache/memcached/MemcachedCacheOps.scala
+++ b/app/com/m3/octoparts/cache/memcached/MemcachedCacheOps.scala
@@ -26,7 +26,10 @@ class MemcachedCacheOps(
       tryApply(directive, CombinedVersionLookup.knownVersions(directive))
     }
 
-    def tryApply(directive: CacheDirective, internalVersions: Seq[Option[Version]]): Option[PartCacheKey] = {
+    def tryApply(
+      directive: CacheDirective,
+      internalVersions: Seq[Option[Version]]
+    ): Option[PartCacheKey] = {
       val aVersionIsUnknown = internalVersions.contains(None)
       if (aVersionIsUnknown) {
         None
@@ -46,8 +49,16 @@ class MemcachedCacheOps(
       fMaybeString.map(maybeString => maybeString.map(Json.parse(_).as[PartResponse]))
     }
 
-    def insertPartResponse(cacheKey: PartCacheKey, partResponse: PartResponse, ttl: Option[Duration])(implicit parentSpan: Span): Future[Unit] =
-      cache.put[String](cacheKey, Json.toJson(partResponse).toString(), calculateTtl(partResponse.cacheControl, ttl))
+    def insertPartResponse(
+      cacheKey: PartCacheKey,
+      partResponse: PartResponse,
+      ttl: Option[Duration]
+    )(implicit parentSpan: Span): Future[Unit] =
+      cache.put[String](
+        cacheKey,
+        Json.toJson(partResponse).toString(),
+        calculateTtl(partResponse.cacheControl, ttl)
+      )
   }
 
   object CombinedVersionLookup {
@@ -58,12 +69,14 @@ class MemcachedCacheOps(
       )
 
     def knownVersions(directive: CacheDirective): Seq[Option[Version]] = {
-      latestVersionCache.getPartVersion(directive.partId) +: directive.versionedParamKeys.map(latestVersionCache.getParamVersion)
+      latestVersionCache.getPartVersion(directive.partId) +:
+        directive.versionedParamKeys.map(latestVersionCache.getParamVersion)
     }
   }
 
   case class CombinedVersionLookup(
-      partVersionLookup: VersionLookup[String], paramVersionLookups: Seq[VersionLookup[VersionedParamKey]]
+      partVersionLookup: VersionLookup[String],
+      paramVersionLookups: Seq[VersionLookup[VersionedParamKey]]
   )(implicit parentSpan: Span) {
 
     lazy val all: Seq[VersionLookup[_]] = partVersionLookup +: paramVersionLookups
@@ -76,20 +89,14 @@ class MemcachedCacheOps(
 
     // will all versions match ?
     def checkVersions: Future[Boolean] = {
-      Future.sequence(all.map {
-        _.willMatch
-      }).map {
-        bools =>
-          !bools.contains(false)
-      }
+      Future.sequence(all.map { _.willMatch })
+        .map { bools => !bools.contains(false) }
     }
 
     // updates the internal cache with versions found in external cache (authoritative)
     // it skips when a version was not found in the external cache
     lazy val updateLocal: Future[Seq[Unit]] = {
-      Future.sequence(all.map {
-        _.updateLocal()
-      })
+      Future.sequence(all.map { _.updateLocal() })
     }
 
     /**
@@ -97,11 +104,8 @@ class MemcachedCacheOps(
      * @return true if something was written to the external cache
      */
     lazy val insertExternal: Future[Boolean] = {
-      Future.sequence(all.map {
-        _.insertExternal()
-      }).map {
-        bools => bools.contains(true)
-      }
+      Future.sequence(all.map { _.insertExternal() })
+        .map { bools => bools.contains(true) }
     }
 
     // both these tasks take care of synchronizing internal and external versions cache.
@@ -110,21 +114,17 @@ class MemcachedCacheOps(
 
   sealed abstract class AbstractVersionCache[T <: java.io.Serializable](id: T) extends VersionCache[T](id) {
     private val versionCodec: Codec[Version] = Codec.LongBinaryCodec
-
     override def pollVersion(implicit parentSpan: Span): Future[Option[Version]] = cache.get[Version](VersionCacheKey(id))(versionCodec, parentSpan)
-
     override def doInsertExternal(version: Version)(implicit parentSpan: Span) = cache.put[Version](VersionCacheKey(id), version, Some(Duration.Inf))(versionCodec, parentSpan)
   }
 
   case class PartVersionCache(id: String) extends AbstractVersionCache(id) {
     override def knownVersion(implicit parentSpan: Span) = latestVersionCache.getPartVersion(id)
-
     override def updateVersion(version: Version)(implicit parentSpan: Span) = latestVersionCache.updatePartVersion(id, version)
   }
 
   case class ParamVersionCache(id: VersionedParamKey) extends AbstractVersionCache(id) {
     override def knownVersion(implicit parentSpan: Span) = latestVersionCache.getParamVersion(id)
-
     override def updateVersion(version: Version)(implicit parentSpan: Span) = latestVersionCache.updateParamVersion(id, version)
   }
 
@@ -165,63 +165,69 @@ class MemcachedCacheOps(
     }
   }
 
-  override def increasePartVersion(partId: String)(implicit parentSpan: Span): Future[Unit] = PartVersionCache(partId).insertNewVersion()
+  override def increasePartVersion(
+    partId: String
+  )(implicit parentSpan: Span): Future[Unit] = PartVersionCache(partId).insertNewVersion()
 
-  override def increaseParamVersion(vpk: VersionedParamKey)(implicit parentSpan: Span): Future[Unit] = ParamVersionCache(vpk).insertNewVersion()
+  override def increaseParamVersion(
+    vpk: VersionedParamKey
+  )(implicit parentSpan: Span): Future[Unit] = ParamVersionCache(vpk).insertNewVersion()
 
   // assumes hashes do not collide : only versions are verified
   private def checkAndReturn(
-    directive: CacheDirective, resp: PartResponse, versionLookups: CombinedVersionLookup
+    directive: CacheDirective,
+    resp: PartResponse,
+    versionLookups: CombinedVersionLookup
   )(implicit parentSpan: Span): Future[Option[PartResponse]] = {
     // really basic check to make sure we return a valid entry
     // e.g. has the right partId
     if (resp.partId == versionLookups.partId) {
-      versionLookups.checkVersions.flatMap {
-        versionWasOk =>
-          if (versionWasOk) {
-            // all green! return the response we already have
-            Future.successful(Some(resp))
-          } else {
-            // some versions differ : synchronize the versions and then make another cache query, only if the cache had all versions set
-            versionLookups.synchronizeVersions.flatMap {
-              _ =>
-                versionLookups.insertExternal.flatMap {
-                  wasInserted =>
-                    if (wasInserted) {
-                      Future.successful(None)
-                    } else {
-                      // all version are there : the cacheKey should be able to be created
-                      // however, the internal version cache may change anytime, so use a fold instead
-                      PartCacheKeyFactory.tryApply(directive).fold {
-                        Future.successful[Option[PartResponse]](None)
-                      } {
-                        cacheKey => PartResponseCache.pollPartResponse(cacheKey)
-                      }
-                    }
+      versionLookups.checkVersions.flatMap { versionWasOk =>
+        if (versionWasOk) {
+          // all green! return the response we already have
+          Future.successful(Some(resp))
+        } else {
+          // some versions differ : synchronize the versions and then make another cache query, only if the cache had all versions set
+          versionLookups.synchronizeVersions.flatMap { _ =>
+            versionLookups.insertExternal.flatMap { wasInserted =>
+              if (wasInserted) {
+                Future.successful(None)
+              } else {
+                // all version are there : the cacheKey should be able to be created
+                // however, the internal version cache may change anytime, so use a fold instead
+                PartCacheKeyFactory.tryApply(directive).fold {
+                  Future.successful[Option[PartResponse]](None)
+                } {
+                  cacheKey => PartResponseCache.pollPartResponse(cacheKey)
                 }
+              }
             }
           }
+        }
       }
     } else {
       Future.successful(None)
     }
   }
 
-  private def onNotFound(finishThisBefore: Future[_], directive: CacheDirective)(f: => Future[PartResponse])(implicit parentSpan: Span): Future[PartResponse] =
+  private def onNotFound(
+    finishThisBefore: Future[_],
+    directive: CacheDirective
+  )(f: => Future[PartResponse])(implicit parentSpan: Span): Future[PartResponse] =
     finishThisBefore.flatMap {
       unused =>
         // not found. shall put it in when f succeeds (if ever)
         val resp: Future[PartResponse] = f
-        resp.onSuccess {
-          case partResponse =>
-            saveLater(partResponse, directive)
-        }
+        resp.onSuccess { case partResponse => saveLater(partResponse, directive) }
         resp
     }
 
   private def mayCache(partResponse: PartResponse): Boolean = !partResponse.cacheControl.noStore
 
-  override def saveLater(partResponse: PartResponse, directive: CacheDirective)(implicit parentSpan: Span): Future[Unit] = {
+  override def saveLater(
+    partResponse: PartResponse,
+    directive: CacheDirective
+  )(implicit parentSpan: Span): Future[Unit] = {
     if (mayCache(partResponse)) {
       // renew the cache key
       // NOTE: At this point, the version futures have completed, so this is the latest known version data
@@ -237,6 +243,8 @@ class MemcachedCacheOps(
     }
   }
 
-  private def setRetrievedFromCacheFlag(partResponse: PartResponse) = partResponse.copy(retrievedFromCache = true)
+  private def setRetrievedFromCacheFlag(
+    partResponse: PartResponse
+  ) = partResponse.copy(retrievedFromCache = true)
 
 }

--- a/app/com/m3/octoparts/cache/memcached/MemcachedRawCache.scala
+++ b/app/com/m3/octoparts/cache/memcached/MemcachedRawCache.scala
@@ -11,14 +11,20 @@ import scala.concurrent.duration.Duration
 /**
  * A Memcached implementation of [[RawCache]] using the Shade library.
  */
-class MemcachedRawCache(memcached: Memcached)(implicit metrics: Metrics) extends RawCache {
+class MemcachedRawCache(
+    memcached: Memcached
+)(implicit metrics: Metrics) extends RawCache {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   def get[T](key: String)(implicit codec: Codec[T], parentSpan: Span) = {
     memcached.get(key).measure("CACHE_GET")
   }
 
-  def set[T](key: String, value: T, ttl: Duration)(implicit codec: Codec[T], parentSpan: Span) = {
+  def set[T](
+    key: String,
+    value: T,
+    ttl: Duration
+  )(implicit codec: Codec[T], parentSpan: Span) = {
     memcached.set(key, value, ttl).measure("CACHE_PUT")
   }
 

--- a/app/com/m3/octoparts/cache/memcached/TtlCalculator.scala
+++ b/app/com/m3/octoparts/cache/memcached/TtlCalculator.scala
@@ -14,7 +14,10 @@ trait TtlCalculator {
    * given the expiresAt field (based on a Cache-Control: max-age header returned from the backend API)
    * and the part's configured TTL.
    */
-  def calculateTtl(cacheControl: CacheControl, configuredTtl: Option[Duration]): Option[Duration] = {
+  def calculateTtl(
+    cacheControl: CacheControl,
+    configuredTtl: Option[Duration]
+  ): Option[Duration] = {
     if (cacheControl.canRevalidate) {
       // if there is a revalidation method, expiresAt does not relate to memcached eviction
       configuredTtl

--- a/app/com/m3/octoparts/cache/versioning/FutureUtil.scala
+++ b/app/com/m3/octoparts/cache/versioning/FutureUtil.scala
@@ -4,28 +4,23 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 private[versioning] object FutureUtil {
 
-  def thenDoIfWasNone(futureOpt: Future[Option[_]])(action: => Future[Unit])(
-    implicit
-    executionContext: ExecutionContext
-  ): Future[Boolean] = {
+  def thenDoIfWasNone(futureOpt: Future[Option[_]])(
+    action: => Future[Unit]
+  )(implicit executionContext: ExecutionContext): Future[Boolean] = {
     futureOpt.flatMap {
       _.fold {
         val result: Future[Unit] = action
-        result.map {
-          unit => true
-        }
+        result.map { unit => true }
       } {
         some => Future.successful[Boolean](false)
       }
     }
   }
 
-  def doIfWasSome[R](futureOpt: Future[Option[R]])(action: R => Unit)(
-    implicit
-    executionContext: ExecutionContext
-  ): Future[Unit] = {
+  def doIfWasSome[R](futureOpt: Future[Option[R]])(
+    action: R => Unit
+  )(implicit executionContext: ExecutionContext): Future[Unit] = {
     futureOpt.map(_.fold {}(action))
   }
 
 }
-

--- a/app/com/m3/octoparts/cache/versioning/FutureUtil.scala
+++ b/app/com/m3/octoparts/cache/versioning/FutureUtil.scala
@@ -5,7 +5,9 @@ import scala.concurrent.{ ExecutionContext, Future }
 private[versioning] object FutureUtil {
 
   def thenDoIfWasNone(futureOpt: Future[Option[_]])(action: => Future[Unit])(
-    implicit executionContext: ExecutionContext): Future[Boolean] = {
+    implicit
+    executionContext: ExecutionContext
+  ): Future[Boolean] = {
     futureOpt.flatMap {
       _.fold {
         val result: Future[Unit] = action
@@ -19,7 +21,9 @@ private[versioning] object FutureUtil {
   }
 
   def doIfWasSome[R](futureOpt: Future[Option[R]])(action: R => Unit)(
-    implicit executionContext: ExecutionContext): Future[Unit] = {
+    implicit
+    executionContext: ExecutionContext
+  ): Future[Unit] = {
     futureOpt.map(_.fold {}(action))
   }
 

--- a/app/com/m3/octoparts/cache/versioning/InMemoryLatestVersionCache.scala
+++ b/app/com/m3/octoparts/cache/versioning/InMemoryLatestVersionCache.scala
@@ -5,7 +5,9 @@ import com.google.common.cache.{ Cache, CacheBuilder }
 /**
  * A simple implementation of [[LatestVersionCache]] that holds the latest versions as Maps
  */
-class InMemoryLatestVersionCache(maxCacheKeys: Long) extends LatestVersionCache {
+class InMemoryLatestVersionCache(
+    maxCacheKeys: Long
+) extends LatestVersionCache {
 
   import com.m3.octoparts.cache.versioning.LatestVersionCache._
 
@@ -16,13 +18,17 @@ class InMemoryLatestVersionCache(maxCacheKeys: Long) extends LatestVersionCache 
     partVersions.put(partId, version)
   }
 
-  def updateParamVersion(versionedParamKey: VersionedParamKey, version: Version): Unit = {
+  def updateParamVersion(
+    versionedParamKey: VersionedParamKey,
+    version: Version
+  ): Unit = {
     paramVersions.put(versionedParamKey, version)
   }
 
   def getPartVersion(partId: PartId) = Option(partVersions.getIfPresent(partId)).map(Long.unbox)
 
-  def getParamVersion(versionedParamKey: VersionedParamKey) = Option(paramVersions.getIfPresent(versionedParamKey)).map(Long.unbox)
+  def getParamVersion(versionedParamKey: VersionedParamKey) =
+    Option(paramVersions.getIfPresent(versionedParamKey)).map(Long.unbox)
 
   private def configureMemoryCache(builder: CacheBuilder[Object, Object]): CacheBuilder[Object, Object] = {
     builder.maximumSize(maxCacheKeys)

--- a/app/com/m3/octoparts/cache/versioning/LatestVersionCache.scala
+++ b/app/com/m3/octoparts/cache/versioning/LatestVersionCache.scala
@@ -52,11 +52,17 @@ trait LatestVersionCache {
   /**
    * Update the latest known cache version for the given parameter value
    */
-  def updateParamVersion(versionedParamKey: VersionedParamKey, version: Version): Unit
+  def updateParamVersion(
+    versionedParamKey: VersionedParamKey,
+    version: Version
+  ): Unit
 
   /**
    * Update the latest known cache version for the given part
    */
-  def updatePartVersion(partId: PartId, version: Version): Unit
+  def updatePartVersion(
+    partId: PartId,
+    version: Version
+  ): Unit
 
 }

--- a/app/com/m3/octoparts/cache/versioning/VersionLookup.scala
+++ b/app/com/m3/octoparts/cache/versioning/VersionLookup.scala
@@ -5,7 +5,11 @@ import com.twitter.zipkin.gen.Span
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class VersionLookup[T](val versionCache: VersionCache[T])(implicit executionContext: ExecutionContext, parentSpan: Span) {
+class VersionLookup[T](
+    val versionCache: VersionCache[T]
+)(implicit
+  executionContext: ExecutionContext,
+    parentSpan: Span) {
 
   import com.m3.octoparts.cache.versioning.FutureUtil._
 
@@ -22,8 +26,7 @@ class VersionLookup[T](val versionCache: VersionCache[T])(implicit executionCont
 
   // version must be defined and matching the known one
   final def willMatch: Future[Boolean] = externalVersion.map {
-    version =>
-      version.fold(false)(internalVersion.contains)
+    version => version.fold(false)(internalVersion.contains)
   }
 
 }

--- a/app/com/m3/octoparts/cache/versioning/VersionedParamKey.scala
+++ b/app/com/m3/octoparts/cache/versioning/VersionedParamKey.scala
@@ -8,5 +8,6 @@ package com.m3.octoparts.cache.versioning
 case class VersionedParamKey(
   partId: String,
   paramName: String,
-  value: String)
+  value: String
+)
 

--- a/app/com/m3/octoparts/cache/versioning/VersionedParamKey.scala
+++ b/app/com/m3/octoparts/cache/versioning/VersionedParamKey.scala
@@ -10,4 +10,3 @@ case class VersionedParamKey(
   paramName: String,
   value: String
 )
-

--- a/app/com/m3/octoparts/future/PromiseSupport.scala
+++ b/app/com/m3/octoparts/future/PromiseSupport.scala
@@ -24,7 +24,10 @@ trait PromiseSupport {
    * @param duration duration for the scheduled promise
    * @return a scheduled promise
    */
-  def timeout[A](message: => A, duration: scala.concurrent.duration.Duration)(implicit ec: ExecutionContext): Future[A] = {
+  def timeout[A](
+    message: => A,
+    duration: scala.concurrent.duration.Duration
+  )(implicit ec: ExecutionContext): Future[A] = {
     timeout(message, duration.toMillis)
   }
 
@@ -35,7 +38,11 @@ trait PromiseSupport {
    * @param duration duration for the scheduled promise
    * @return a scheduled promise
    */
-  def timeout[A](message: => A, duration: Long, unit: TimeUnit = TimeUnit.MILLISECONDS)(implicit ec: ExecutionContext): Future[A] = {
+  def timeout[A](
+    message: => A,
+    duration: Long,
+    unit: TimeUnit = TimeUnit.MILLISECONDS
+  )(implicit ec: ExecutionContext): Future[A] = {
     val p = SPromise[A]()
     actorSystem.scheduler.scheduleOnce(FiniteDuration(duration, unit)) {
       p.complete(Try(message))

--- a/app/com/m3/octoparts/future/RichFutureWithTimeout.scala
+++ b/app/com/m3/octoparts/future/RichFutureWithTimeout.scala
@@ -21,7 +21,9 @@ object RichFutureWithTimeout {
     case NonFatal(e) if Play.maybeApplication.fold(false)(_.mode == Mode.Test) => actorSystem.dispatcher
   }
 
-  implicit class RichFutureWithTimeoutOps[A](val f: Future[A]) extends AnyVal {
+  implicit class RichFutureWithTimeoutOps[A](
+      val f: Future[A]
+  ) extends AnyVal {
 
     /**
      * An enrichment method for Future[A] that allows us to specify an

--- a/app/com/m3/octoparts/future/RichFutureWithTiming.scala
+++ b/app/com/m3/octoparts/future/RichFutureWithTiming.scala
@@ -11,7 +11,9 @@ object RichFutureWithTiming {
   /**
    * Enrichment for scala.concurrent.Future adding methods for measuring execution time.
    */
-  implicit class RichFutureWithTimingOps[A](val future: Future[A]) extends AnyVal {
+  implicit class RichFutureWithTimingOps[A](
+      val future: Future[A]
+  ) extends AnyVal {
 
     /**
      * Measures time (the `tapper` callback is called asynchronously)
@@ -44,4 +46,3 @@ object RichFutureWithTiming {
     }
   }
 }
-

--- a/app/com/m3/octoparts/http/HttpClientPool.scala
+++ b/app/com/m3/octoparts/http/HttpClientPool.scala
@@ -43,6 +43,7 @@ object HttpClientPool {
       httpConnectionTimeout = part.httpConnectionTimeout,
       httpSocketTimeout = part.httpSocketTimeout,
       httpDefaultEncoding = part.httpDefaultEncoding.underlying,
-      httpProxySettings = part.httpProxySettings)
+      httpProxySettings = part.httpProxySettings
+    )
   }
 }

--- a/app/com/m3/octoparts/http/HttpClientPool.scala
+++ b/app/com/m3/octoparts/http/HttpClientPool.scala
@@ -14,7 +14,9 @@ import scala.util.Try
  * A pool to manage HTTP clients.
  * Holds one HTTP client per partId.
  */
-class HttpClientPool(metrics: Metrics) extends KeyedResourcePool[HttpPartConfigClientKey, HttpClientLike] {
+class HttpClientPool(
+    metrics: Metrics
+) extends KeyedResourcePool[HttpPartConfigClientKey, HttpClientLike] {
 
   protected def makeNew(key: HttpPartConfigClientKey) = new InstrumentedHttpClient(
     name = key.partId,
@@ -34,7 +36,14 @@ class HttpClientPool(metrics: Metrics) extends KeyedResourcePool[HttpPartConfigC
 }
 
 object HttpClientPool {
-  case class HttpPartConfigClientKey(partId: String, httpPoolSize: Int, httpConnectionTimeout: FiniteDuration, httpSocketTimeout: FiniteDuration, httpDefaultEncoding: Charset, httpProxySettings: Option[HttpProxySettings])
+  case class HttpPartConfigClientKey(
+    partId: String,
+    httpPoolSize: Int,
+    httpConnectionTimeout: FiniteDuration,
+    httpSocketTimeout: FiniteDuration,
+    httpDefaultEncoding: Charset,
+    httpProxySettings: Option[HttpProxySettings]
+  )
 
   object HttpPartConfigClientKey {
     def apply(part: HttpPartConfig): HttpPartConfigClientKey = HttpPartConfigClientKey(

--- a/app/com/m3/octoparts/http/HttpResponse.scala
+++ b/app/com/m3/octoparts/http/HttpResponse.scala
@@ -28,4 +28,5 @@ case class HttpResponse(
   charset: Option[String] = None,
   cacheControl: CacheControl = CacheControl.NotSet,
   fromFallback: Boolean = false,
-  body: Option[String] = None)
+  body: Option[String] = None
+)

--- a/app/com/m3/octoparts/http/HttpResponseHandler.scala
+++ b/app/com/m3/octoparts/http/HttpResponseHandler.scala
@@ -17,7 +17,9 @@ import scala.util.Try
 /**
  * Custom HttpResponseHandler that returns a [[HttpResponse]] case class
  */
-class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[HttpResponse] {
+class HttpResponseHandler(
+    defaultEncoding: Charset
+) extends ResponseHandler[HttpResponse] {
   /**
    * Given a HttpResponse from the Apache HttpClient lib, returns our nice
    * HttpResponse case class
@@ -104,4 +106,3 @@ class HttpResponseHandler(defaultEncoding: Charset) extends ResponseHandler[Http
     CacheControl(noStore, noCache, expiresAt, etag, lastModified)
   }
 }
-

--- a/app/com/m3/octoparts/http/InstrumentedHttpClient.scala
+++ b/app/com/m3/octoparts/http/InstrumentedHttpClient.scala
@@ -41,8 +41,7 @@ class InstrumentedHttpClient(
   defaultEncoding: Charset,
   mbProxySettings: Option[HttpProxySettings],
   metrics: Metrics
-)
-    extends HttpClientLike
+) extends HttpClientLike
     with Closeable {
   import com.m3.octoparts.http.InstrumentedHttpClient._
 

--- a/app/com/m3/octoparts/http/InstrumentedHttpClient.scala
+++ b/app/com/m3/octoparts/http/InstrumentedHttpClient.scala
@@ -40,7 +40,8 @@ class InstrumentedHttpClient(
   socketTimeout: FiniteDuration,
   defaultEncoding: Charset,
   mbProxySettings: Option[HttpProxySettings],
-  metrics: Metrics)
+  metrics: Metrics
+)
     extends HttpClientLike
     with Closeable {
   import com.m3.octoparts.http.InstrumentedHttpClient._

--- a/app/com/m3/octoparts/hystrix/HystrixExecutor.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixExecutor.scala
@@ -5,7 +5,9 @@ import com.netflix.hystrix.HystrixCommand
 
 import scala.concurrent.Future
 
-case class HystrixExecutor(config: HttpPartConfig) extends HystrixSetterSupport {
+case class HystrixExecutor(
+    config: HttpPartConfig
+) extends HystrixSetterSupport {
 
   /**
    * Returns a Future result of the block passed, run within the context

--- a/app/com/m3/octoparts/hystrix/HystrixHealthReporter.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixHealthReporter.scala
@@ -10,7 +10,9 @@ trait HystrixHealthReporter {
 
 }
 
-object HystrixHealthReporter extends HystrixHealthReporter with HystrixCommandMetricsRepository {
+object HystrixHealthReporter
+    extends HystrixHealthReporter
+    with HystrixCommandMetricsRepository {
 
   /**
    * Get a list of all command keys whose circuit breakers are currently open

--- a/app/com/m3/octoparts/hystrix/HystrixMetricsLogger.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixMetricsLogger.scala
@@ -7,7 +7,9 @@ import play.api.Logger
  * Helper for outputting Hystrix metrics logs in LTSV format.
  * These logs are written to a separate log file for tailing by fluentd.
  */
-object HystrixMetricsLogger extends HystrixCommandMetricsRepository with LTSVLoggerLike {
+object HystrixMetricsLogger
+    extends HystrixCommandMetricsRepository
+    with LTSVLoggerLike {
 
   val underlyingLogger = Logger("HystrixMetrics").underlyingLogger
 

--- a/app/com/m3/octoparts/hystrix/HystrixMetricsLogger.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixMetricsLogger.scala
@@ -41,7 +41,8 @@ object HystrixMetricsLogger extends HystrixCommandMetricsRepository with LTSVLog
     execTimeMsMedian: Int,
     execTimeMs95: Int,
     execTimeMs99: Int,
-    execTimeMs998: Int): Unit = {
+    execTimeMs998: Int
+  ): Unit = {
 
     info(
       "commandName" -> commandName,

--- a/app/com/m3/octoparts/hystrix/HystrixSetterSupport.scala
+++ b/app/com/m3/octoparts/hystrix/HystrixSetterSupport.scala
@@ -17,20 +17,24 @@ trait HystrixSetterSupport {
     val threadPoolConfig: ThreadPoolConfig = config.threadPoolConfigItem
     val threadPoolProperties = threadPoolSetter(threadPoolConfig)
 
-    HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(config.commandGroupKey)).
-      andCommandKey(HystrixCommandKey.Factory.asKey(config.commandKey)).
-      andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(threadPoolConfig.threadPoolKey)).
-      andThreadPoolPropertiesDefaults(threadPoolProperties).
-      andCommandPropertiesDefaults(HystrixCommandProperties.Setter().
-        withExecutionTimeoutInMilliseconds(config.timeout.toMillis.toInt).
-        withFallbackEnabled(config.localContentsAsFallback))
+    HystrixCommand.Setter
+      .withGroupKey(HystrixCommandGroupKey.Factory.asKey(config.commandGroupKey))
+      .andCommandKey(HystrixCommandKey.Factory.asKey(config.commandKey))
+      .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(threadPoolConfig.threadPoolKey))
+      .andThreadPoolPropertiesDefaults(threadPoolProperties)
+      .andCommandPropertiesDefaults(
+        HystrixCommandProperties.Setter()
+          .withExecutionTimeoutInMilliseconds(config.timeout.toMillis.toInt)
+          .withFallbackEnabled(config.localContentsAsFallback)
+      )
   }
 
   private[hystrix] def threadPoolSetter(threadPoolConfig: ThreadPoolConfig): Setter = {
-    HystrixThreadPoolProperties.Setter().
-      withCoreSize(threadPoolConfig.coreSize).
+    HystrixThreadPoolProperties.Setter()
+      .withCoreSize(threadPoolConfig.coreSize)
       // Hystrix uses both of these for setting Queue size
-      withMaxQueueSize(threadPoolConfig.queueSize).
-      withQueueSizeRejectionThreshold(threadPoolConfig.queueSize)
+      .withMaxQueueSize(threadPoolConfig.queueSize)
+      .withQueueSizeRejectionThreshold(threadPoolConfig.queueSize)
   }
+
 }

--- a/app/com/m3/octoparts/hystrix/KeyAndBuilderValuesHystrixPropertiesStrategy.scala
+++ b/app/com/m3/octoparts/hystrix/KeyAndBuilderValuesHystrixPropertiesStrategy.scala
@@ -8,14 +8,18 @@ import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy
 /**
  * Custom [[HystrixPropertiesStrategy]] implementation
  */
-class KeyAndBuilderValuesHystrixPropertiesStrategy extends HystrixPropertiesStrategy {
+class KeyAndBuilderValuesHystrixPropertiesStrategy
+    extends HystrixPropertiesStrategy {
+
   private val mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
 
   /**
    * Overridden to return a [[String]] that is a combination of the commandKey name and a JSON string
    * of the builder values
    */
-  override def getCommandPropertiesCacheKey(commandKey: HystrixCommandKey, builder: HystrixCommandProperties.Setter): String =
-    s"${commandKey.name()}-${mapper.writeValueAsString(builder)}"
+  override def getCommandPropertiesCacheKey(
+    commandKey: HystrixCommandKey,
+    builder: HystrixCommandProperties.Setter
+  ): String = s"${commandKey.name()}-${mapper.writeValueAsString(builder)}"
 
 }

--- a/app/com/m3/octoparts/logging/LTSVables.scala
+++ b/app/com/m3/octoparts/logging/LTSVables.scala
@@ -50,7 +50,9 @@ object LTSVables extends LogUtil {
    * If we need more, add more of these
    */
   implicit def pairsLTSVable[A: LTSVable, B: LTSVable]: LTSVable[(A, B)] = new LTSVable[(A, B)] {
-    def toPairs(o: (A, B)): Seq[(String, Any)] = implicitly[LTSVable[A]].toPairs(o._1) ++ implicitly[LTSVable[B]].toPairs(o._2)
+    def toPairs(o: (A, B)): Seq[(String, Any)] =
+      implicitly[LTSVable[A]].toPairs(o._1) ++
+        implicitly[LTSVable[B]].toPairs(o._2)
   }
 
 }

--- a/app/com/m3/octoparts/logging/PartRequestLogger.scala
+++ b/app/com/m3/octoparts/logging/PartRequestLogger.scala
@@ -9,11 +9,27 @@ import play.api.Logger
  */
 trait PartRequestLogger {
 
-  def logSuccess(partId: String, parentRequestId: String, serviceId: Option[String], cacheHit: Boolean, responseMs: Long): Unit
+  def logSuccess(
+    partId: String,
+    parentRequestId: String,
+    serviceId: Option[String],
+    cacheHit: Boolean,
+    responseMs: Long
+  ): Unit
 
-  def logFailure(partId: String, parentRequestId: String, serviceId: Option[String], statusCode: Option[Int]): Unit
+  def logFailure(
+    partId: String,
+    parentRequestId: String,
+    serviceId: Option[String],
+    statusCode: Option[Int]
+  ): Unit
 
-  def logTimeout(partId: String, parentRequestId: String, serviceId: Option[String], timeoutMs: Long): Unit
+  def logTimeout(
+    partId: String,
+    parentRequestId: String,
+    serviceId: Option[String],
+    timeoutMs: Long
+  ): Unit
 
 }
 
@@ -21,7 +37,13 @@ object PartRequestLogger extends PartRequestLogger with LTSVLoggerLike {
 
   val underlyingLogger = Logger("PartRequests").underlyingLogger
 
-  def logSuccess(partId: String, parentRequestId: String, serviceId: Option[String], cacheHit: Boolean, responseMs: Long): Unit = {
+  def logSuccess(
+    partId: String,
+    parentRequestId: String,
+    serviceId: Option[String],
+    cacheHit: Boolean,
+    responseMs: Long
+  ): Unit = {
     val hitOrMiss = if (cacheHit) "hit" else "miss"
     info(
       "partId" -> partId,
@@ -32,7 +54,12 @@ object PartRequestLogger extends PartRequestLogger with LTSVLoggerLike {
     )
   }
 
-  def logFailure(partId: String, parentRequestId: String, serviceId: Option[String], statusCode: Option[Int]): Unit = {
+  def logFailure(
+    partId: String,
+    parentRequestId: String,
+    serviceId: Option[String],
+    statusCode: Option[Int]
+  ): Unit = {
     info(
       "partId" -> partId,
       "result" -> "failure",
@@ -42,7 +69,12 @@ object PartRequestLogger extends PartRequestLogger with LTSVLoggerLike {
     )
   }
 
-  def logTimeout(partId: String, parentRequestId: String, serviceId: Option[String], timeoutMs: Long): Unit = {
+  def logTimeout(
+    partId: String,
+    parentRequestId: String,
+    serviceId: Option[String],
+    timeoutMs: Long
+  ): Unit = {
     info(
       "partId" -> partId,
       "result" -> "timeout",
@@ -51,4 +83,5 @@ object PartRequestLogger extends PartRequestLogger with LTSVLoggerLike {
       "timeoutMs" -> timeoutMs
     )
   }
+
 }

--- a/app/com/m3/octoparts/model/config/CacheGroup.scala
+++ b/app/com/m3/octoparts/model/config/CacheGroup.scala
@@ -16,7 +16,8 @@ case class CacheGroup(
   httpPartConfigs: SortedSet[HttpPartConfig] = SortedSet.empty,
   partParams: SortedSet[PartParam] = SortedSet.empty,
   createdAt: DateTime,
-  updatedAt: DateTime) extends ConfigModel[CacheGroup]
+  updatedAt: DateTime
+) extends ConfigModel[CacheGroup]
 
 object CacheGroup {
 

--- a/app/com/m3/octoparts/model/config/HttpPartConfig.scala
+++ b/app/com/m3/octoparts/model/config/HttpPartConfig.scala
@@ -19,7 +19,7 @@ import scala.util.Try
  * @param localContents the static contents which is used instead of actual contents of this part
  */
 case class HttpPartConfig(
-  id: Option[Long] = None, // None means that the record is new
+    id: Option[Long] = None, // None means that the record is new
     partId: String,
     owner: String,
     description: Option[String],

--- a/app/com/m3/octoparts/model/config/HttpPartConfig.scala
+++ b/app/com/m3/octoparts/model/config/HttpPartConfig.scala
@@ -18,32 +18,34 @@ import scala.util.Try
  * @param localContentsEnabled whether local contents is enabled
  * @param localContents the static contents which is used instead of actual contents of this part
  */
-case class HttpPartConfig(id: Option[Long] = None, // None means that the record is new
-                          partId: String,
-                          owner: String,
-                          description: Option[String],
-                          uriToInterpolate: String,
-                          method: HttpMethod.Value,
-                          additionalValidStatuses: SortedSet[Int] = SortedSet.empty,
-                          httpPoolSize: Int,
-                          httpConnectionTimeout: FiniteDuration,
-                          httpSocketTimeout: FiniteDuration,
-                          httpDefaultEncoding: Charset,
-                          httpProxy: Option[String] = None,
-                          parameters: SortedSet[PartParam] = SortedSet.empty,
-                          hystrixConfig: Option[HystrixConfig] = None,
-                          deprecatedInFavourOf: Option[String] = None,
-                          cacheGroups: SortedSet[CacheGroup] = SortedSet.empty,
-                          cacheTtl: Option[FiniteDuration] = Some(Duration.Zero), // in seconds
-                          alertMailsEnabled: Boolean,
-                          alertAbsoluteThreshold: Option[Int],
-                          alertPercentThreshold: Option[Double],
-                          alertInterval: FiniteDuration,
-                          alertMailRecipients: Option[String],
-                          localContentsEnabled: Boolean,
-                          localContents: Option[String],
-                          createdAt: DateTime,
-                          updatedAt: DateTime) extends ConfigModel[HttpPartConfig] {
+case class HttpPartConfig(
+  id: Option[Long] = None, // None means that the record is new
+    partId: String,
+    owner: String,
+    description: Option[String],
+    uriToInterpolate: String,
+    method: HttpMethod.Value,
+    additionalValidStatuses: SortedSet[Int] = SortedSet.empty,
+    httpPoolSize: Int,
+    httpConnectionTimeout: FiniteDuration,
+    httpSocketTimeout: FiniteDuration,
+    httpDefaultEncoding: Charset,
+    httpProxy: Option[String] = None,
+    parameters: SortedSet[PartParam] = SortedSet.empty,
+    hystrixConfig: Option[HystrixConfig] = None,
+    deprecatedInFavourOf: Option[String] = None,
+    cacheGroups: SortedSet[CacheGroup] = SortedSet.empty,
+    cacheTtl: Option[FiniteDuration] = Some(Duration.Zero), // in seconds
+    alertMailsEnabled: Boolean,
+    alertAbsoluteThreshold: Option[Int],
+    alertPercentThreshold: Option[Double],
+    alertInterval: FiniteDuration,
+    alertMailRecipients: Option[String],
+    localContentsEnabled: Boolean,
+    localContents: Option[String],
+    createdAt: DateTime,
+    updatedAt: DateTime
+) extends ConfigModel[HttpPartConfig] {
   /**
    * Method to use when we are sure we have a HystrixConfig inside the
    * hystrixConfig field.
@@ -109,7 +111,8 @@ object HttpPartConfig {
         alertAbsoluteThreshold = config.alertAbsoluteThreshold,
         alertPercentThreshold = config.alertPercentThreshold,
         alertInterval = config.alertInterval,
-        alertMailRecipients = config.alertMailRecipients),
+        alertMailRecipients = config.alertMailRecipients
+      ),
       localContentsEnabled = config.localContentsEnabled,
       localContents = config.localContents
     )

--- a/app/com/m3/octoparts/model/config/HttpPartConfigCacheGroup.scala
+++ b/app/com/m3/octoparts/model/config/HttpPartConfigCacheGroup.scala
@@ -3,4 +3,5 @@ package com.m3.octoparts.model.config
 // Intersection class and mapper to facilitate many-to-many with CacheGroup
 case class HttpPartConfigCacheGroup(
   cacheGroupId: Long,
-  httpPartConfigId: Long)
+  httpPartConfigId: Long
+)

--- a/app/com/m3/octoparts/model/config/HttpProxySettings.scala
+++ b/app/com/m3/octoparts/model/config/HttpProxySettings.scala
@@ -6,7 +6,11 @@ import org.parboiled2._
 
 import scala.util.Try
 
-case class HttpProxySettings(scheme: String, host: String, port: Int) {
+case class HttpProxySettings(
+    scheme: String,
+    host: String,
+    port: Int
+) {
 
   import com.m3.octoparts.model.config.HttpProxySettings._
 
@@ -37,7 +41,9 @@ object HttpProxySettings {
    */
   def isValid(ser: String): Boolean = parse(ser).isSuccess
 
-  private class HttpProxySettingsParser(input: ParserInput) extends DefaultUriParser(input, UriConfig.default) {
+  private class HttpProxySettingsParser(
+      input: ParserInput
+  ) extends DefaultUriParser(input, UriConfig.default) {
     import HttpProxySettingsParser._
     import org.parboiled2._
 

--- a/app/com/m3/octoparts/model/config/HystrixConfig.scala
+++ b/app/com/m3/octoparts/model/config/HystrixConfig.scala
@@ -51,7 +51,8 @@ case class HystrixConfig(
     timeout: FiniteDuration = HystrixConfig.defaultTimeout,
     localContentsAsFallback: Boolean,
     createdAt: DateTime,
-    updatedAt: DateTime) extends ConfigModel[HystrixConfig] {
+    updatedAt: DateTime
+) extends ConfigModel[HystrixConfig] {
 
   /**
    * Method to use when we are sure we have a ThreadPoolConfig inside the

--- a/app/com/m3/octoparts/model/config/PartParam.scala
+++ b/app/com/m3/octoparts/model/config/PartParam.scala
@@ -28,7 +28,8 @@ case class PartParam(
     inputNameOverride: Option[String] = None,
     cacheGroups: SortedSet[CacheGroup] = SortedSet.empty,
     createdAt: DateTime,
-    updatedAt: DateTime) extends ConfigModel[PartParam] {
+    updatedAt: DateTime
+) extends ConfigModel[PartParam] {
 
   /**
    * This is the key used to look for a value inside the PartRequest

--- a/app/com/m3/octoparts/model/config/PartParamCacheGroup.scala
+++ b/app/com/m3/octoparts/model/config/PartParamCacheGroup.scala
@@ -3,4 +3,5 @@ package com.m3.octoparts.model.config
 // Intersection class and mapper to facilitate many-to-many with CacheGroup
 case class PartParamCacheGroup(
   cacheGroupId: Long,
-  partParamId: Long)
+  partParamId: Long
+)

--- a/app/com/m3/octoparts/model/config/ShortPartParam.scala
+++ b/app/com/m3/octoparts/model/config/ShortPartParam.scala
@@ -1,7 +1,12 @@
 package com.m3.octoparts.model.config
 
-object ShortPartParam {
-  def apply(partParam: PartParam): ShortPartParam = apply(partParam.outputName, partParam.paramType)
-}
+case class ShortPartParam(
+  outputName: String,
+  paramType: ParamType.Value
+)
 
-case class ShortPartParam(outputName: String, paramType: ParamType.Value)
+object ShortPartParam {
+
+  def apply(partParam: PartParam): ShortPartParam = apply(partParam.outputName, partParam.paramType)
+
+}

--- a/app/com/m3/octoparts/model/config/ThreadPoolConfig.scala
+++ b/app/com/m3/octoparts/model/config/ThreadPoolConfig.scala
@@ -15,7 +15,8 @@ case class ThreadPoolConfig(
     hystrixConfigs: Set[HystrixConfig] = Set.empty,
     queueSize: Int = ThreadPoolConfig.defaultQueueSize,
     createdAt: DateTime,
-    updatedAt: DateTime) extends ConfigModel[ThreadPoolConfig] {
+    updatedAt: DateTime
+) extends ConfigModel[ThreadPoolConfig] {
 
   /**
    * @return a sorted list of related [[HttpPartConfig]]
@@ -36,7 +37,8 @@ object ThreadPoolConfig {
     JsonThreadPoolConfig(
       threadPoolKey = config.threadPoolKey,
       coreSize = config.coreSize,
-      queueSize = config.queueSize)
+      queueSize = config.queueSize
+    )
   }
 
   def fromJsonModel(config: JsonThreadPoolConfig): ThreadPoolConfig = {

--- a/app/com/m3/octoparts/repository/CachingRepository.scala
+++ b/app/com/m3/octoparts/repository/CachingRepository.scala
@@ -32,7 +32,10 @@ trait CachingRepository extends ConfigsRepository {
   /**
    * Generic method for putting something into cache using any kind of identifier
    */
-  def put[A](cacheKey: CacheKey, maybeCacheable: Option[A])(implicit parentSpan: Span): Future[Unit] = {
+  def put[A](
+    cacheKey: CacheKey,
+    maybeCacheable: Option[A]
+  )(implicit parentSpan: Span): Future[Unit] = {
     cache.put(cacheKey, maybeCacheable, Some(Duration.Inf)).recover {
       // no need to propagate cache put errors
       case NonFatal(cacheFailure) =>
@@ -58,22 +61,27 @@ trait CachingRepository extends ConfigsRepository {
    * Given a function that returns a Future Sequence of A and a function that turns
    * each A into a CacheKey, performs a find-and-cache
    */
-  private def findAllAndCache[A](findAll: => Future[SortedSet[A]])(cacheKey: A => CacheKey)(implicit parentSpan: Span): Future[Unit] = {
+  private def findAllAndCache[A](
+    findAll: => Future[SortedSet[A]]
+  )(cacheKey: A => CacheKey)(implicit parentSpan: Span): Future[Unit] = {
     for {
       all <- findAll
       _ <- Future.sequence(all.toSeq.map(obj => put(cacheKey(obj), Some(obj))))
     } yield {}
   }
 
-  def findConfigByPartId(partId: String)(implicit parentSpan: Span) = fetchFromCacheOrElse(partId)(delegate.findConfigByPartId, HttpPartConfigCacheKey(_))
+  def findConfigByPartId(partId: String)(implicit parentSpan: Span) =
+    fetchFromCacheOrElse(partId)(delegate.findConfigByPartId, HttpPartConfigCacheKey(_))
 
   def findParamById(id: Long)(implicit parentSpan: Span) = delegate.findParamById(id)
 
   def findAllCacheGroups()(implicit parentSpan: Span) = delegate.findAllCacheGroups()
 
-  def findCacheGroupByName(name: String)(implicit parentSpan: Span) = fetchFromCacheOrElse(name)(delegate.findCacheGroupByName, CacheGroupCacheKey(_))
+  def findCacheGroupByName(name: String)(implicit parentSpan: Span) =
+    fetchFromCacheOrElse(name)(delegate.findCacheGroupByName, CacheGroupCacheKey(_))
 
-  def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span) = delegate.findAllCacheGroupsByName(names: _*)
+  def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span) =
+    delegate.findAllCacheGroupsByName(names: _*)
 
   /**
    * Generic Cache-decorated fetch
@@ -89,24 +97,37 @@ trait CachingRepository extends ConfigsRepository {
    * cache-fetch miss, fetch2 finishes with an error and we end up trying to do another fetch from
    * the database but that is hard to side-step (and might not be such a bad thing)
    */
-  private def fetchFromCacheOrElse[A, B](identifier: A)(notFromCacheFind: A => Future[Option[B]], cacheKey: A => CacheKey)(implicit parentSpan: Span): Future[Option[B]] = {
-    cache.get[Option[B]](cacheKey(identifier)).flatMap {
-      _.fold {
-        val fMaybeDBConfig = notFromCacheFind(identifier)
-        fMaybeDBConfig.foreach(put(cacheKey(identifier), _))
-        fMaybeDBConfig
-      }(Future.successful)
-    }.recoverWith {
-      case NonFatal(e) =>
-        Option(e.getCause).fold {
-          LTSVLogger.error(e, "Cache retrieve this identifier" -> identifier.toString)
-        } {
-          case cause: shade.TimeoutException => LTSVLogger.warn("Cache retrieve timed out for this identifier" -> identifier.toString)
-          case cause => LTSVLogger.error(cause, "Cache retrieve this identifier" -> identifier.toString)
-        }
+  private def fetchFromCacheOrElse[A, B](identifier: A)(
+    notFromCacheFind: A => Future[Option[B]],
+    cacheKey: A => CacheKey
+  )(implicit parentSpan: Span): Future[Option[B]] = {
+    cache.get[Option[B]](cacheKey(identifier))
+      .flatMap {
+        _.fold {
+          val fMaybeDBConfig = notFromCacheFind(identifier)
+          fMaybeDBConfig.foreach(put(cacheKey(identifier), _))
+          fMaybeDBConfig
+        }(Future.successful)
+      }.recoverWith {
+        case NonFatal(e) =>
+          Option(e.getCause).fold {
+            LTSVLogger.error(
+              e,
+              "Cache retrieve this identifier" -> identifier.toString
+            )
+          } {
+            case cause: shade.TimeoutException =>
+              LTSVLogger.warn(
+                "Cache retrieve timed out for this identifier" -> identifier.toString
+              )
+            case cause => LTSVLogger.error(
+              cause,
+              "Cache retrieve this identifier" -> identifier.toString
+            )
+          }
 
-        notFromCacheFind(identifier)
-    }
+          notFromCacheFind(identifier)
+      }
   }
 
   // ------ The below methods are NOT cached ------
@@ -116,10 +137,8 @@ trait CachingRepository extends ConfigsRepository {
   def findAllConfigs()(implicit parentSpan: Span) = delegate.findAllConfigs().flatMap {
     cSeq =>
       val futures = Future.sequence(cSeq.toSeq.map { config =>
-        {
-          put(HttpPartConfigCacheKey(config.partId), Some(config)).map {
-            finished => config
-          }
+        put(HttpPartConfigCacheKey(config.partId), Some(config)).map {
+          finished => config
         }
       })
       // Shutdown any HTTP clients for parts that no longer exist or require a renewal of the HTTP client
@@ -128,9 +147,11 @@ trait CachingRepository extends ConfigsRepository {
   }
 
   // not cached
-  def findThreadPoolConfigById(id: Long)(implicit parentSpan: Span) = delegate.findThreadPoolConfigById(id)
+  def findThreadPoolConfigById(id: Long)(implicit parentSpan: Span) =
+    delegate.findThreadPoolConfigById(id)
 
   // not cached
-  def findAllThreadPoolConfigs()(implicit parentSpan: Span) = delegate.findAllThreadPoolConfigs()
+  def findAllThreadPoolConfigs()(implicit parentSpan: Span) =
+    delegate.findAllThreadPoolConfigs()
 
 }

--- a/app/com/m3/octoparts/repository/ConfigImporter.scala
+++ b/app/com/m3/octoparts/repository/ConfigImporter.scala
@@ -13,9 +13,15 @@ import scala.concurrent.Future
 trait ConfigImporter {
   self: MutableDBRepository with ImmutableDBRepository =>
 
-  def importConfigs(configs: Seq[json.HttpPartConfig])(implicit parentSpan: Span) = DB.futureLocalTx { implicit session => importConfigsWithSession(configs) }
+  def importConfigs(configs: Seq[json.HttpPartConfig])(implicit parentSpan: Span) = {
+    DB.futureLocalTx { implicit session =>
+      importConfigsWithSession(configs)
+    }
+  }
 
-  private[repository] class ImportAction(uniqueConfigs: SortedSet[json.HttpPartConfig])(implicit session: DBSession) {
+  private[repository] class ImportAction(
+      uniqueConfigs: SortedSet[json.HttpPartConfig]
+  )(implicit session: DBSession) {
     // this must be done beforehand because imports will be run in parallel
     // insert thread pools first
     val fThreadPoolConfigs: Future[Map[String, Long]] = {
@@ -23,21 +29,36 @@ trait ConfigImporter {
        * If a [[ThreadPoolConfig]] with the same [[ThreadPoolConfig.threadPoolKey]] exists in DB, returns its ID.
        * Else, inserts a new [[ThreadPoolConfig]] and returns its ID
        */
-      def insertThreadPoolConfigIfMissing(threadPoolConfig: json.ThreadPoolConfig)(implicit session: DBSession): Future[(String, Long)] = {
-        val oldThreadPoolConfig = getWithSession(ThreadPoolConfigRepository, sqls.eq(ThreadPoolConfigRepository.defaultAlias.threadPoolKey, threadPoolConfig.threadPoolKey))
+      def insertThreadPoolConfigIfMissing(
+        threadPoolConfig: json.ThreadPoolConfig
+      )(implicit session: DBSession): Future[(String, Long)] = {
+        val oldThreadPoolConfig = getWithSession(
+          ThreadPoolConfigRepository,
+          sqls.eq(
+            ThreadPoolConfigRepository.defaultAlias.threadPoolKey,
+            threadPoolConfig.threadPoolKey
+          )
+        )
         oldThreadPoolConfig.flatMap { mbTpcWasThere =>
           mbTpcWasThere.fold {
-            saveWithSession(ThreadPoolConfigRepository, ThreadPoolConfig.fromJsonModel(threadPoolConfig)).map(threadPoolConfig.threadPoolKey -> _)
+            saveWithSession(
+              ThreadPoolConfigRepository,
+              ThreadPoolConfig.fromJsonModel(threadPoolConfig)
+            ).map(threadPoolConfig.threadPoolKey -> _)
           } {
             tpcWasThere =>
-              LTSVLogger.debug("Thread pool" -> tpcWasThere.threadPoolKey, "Action" -> "Skipping import")
+              LTSVLogger.debug(
+                "Thread pool" -> tpcWasThere.threadPoolKey,
+                "Action" -> "Skipping import"
+              )
               Future.successful(threadPoolConfig.threadPoolKey -> tpcWasThere.id.get)
           }
         }
       }
 
       val threadPoolConfigs = uniqueConfigs.map(_.hystrixConfig.threadPoolConfig)
-      Future.sequence[(String, Long), Seq](threadPoolConfigs.toSeq.map(insertThreadPoolConfigIfMissing)).map(_.toMap)
+      Future.sequence[(String, Long), Seq](threadPoolConfigs.toSeq.map(insertThreadPoolConfigIfMissing))
+        .map(_.toMap)
     }
 
     val fCacheGroups: Future[Map[String, CacheGroup]] = {
@@ -46,32 +67,53 @@ trait ConfigImporter {
        * If a [[CacheGroup]] with the same name exists in DB, returns it.
        * Else, inserts a new [[CacheGroup]] and returns it
        */
-      def insertCacheGroupIfMissing(jCacheGroup: json.CacheGroup)(implicit session: DBSession): Future[(String, CacheGroup)] = {
-        val oldCacheGroupConfig = getWithSession(CacheGroupRepository, sqls.eq(CacheGroupRepository.defaultAlias.name, jCacheGroup.name))
+      def insertCacheGroupIfMissing(
+        jCacheGroup: json.CacheGroup
+      )(implicit session: DBSession): Future[(String, CacheGroup)] = {
+        val oldCacheGroupConfig = getWithSession(
+          CacheGroupRepository,
+          sqls.eq(CacheGroupRepository.defaultAlias.name, jCacheGroup.name)
+        )
         oldCacheGroupConfig.flatMap { mbCgWasThere =>
           mbCgWasThere.fold {
-            val fCacheGroupId = saveWithSession(CacheGroupRepository, CacheGroup.fromJsonModel(jCacheGroup))
+            val fCacheGroupId = saveWithSession(
+              CacheGroupRepository,
+              CacheGroup.fromJsonModel(jCacheGroup)
+            )
             fCacheGroupId.flatMap { cacheGroupId =>
-              getWithSession(CacheGroupRepository, sqls.eq(CacheGroupRepository.defaultAlias.id, cacheGroupId)).map(jCacheGroup.name -> _.get)
+              getWithSession(
+                CacheGroupRepository,
+                sqls.eq(CacheGroupRepository.defaultAlias.id, cacheGroupId)
+              ).map(jCacheGroup.name -> _.get)
             }
           } { cgWasThere =>
-            LTSVLogger.debug("Cache group" -> cgWasThere.name, "Action" -> "Skipping import")
+            LTSVLogger.debug(
+              "Cache group" -> cgWasThere.name,
+              "Action" -> "Skipping import"
+            )
             Future.successful(cgWasThere.name -> cgWasThere)
           }
         }
       }
 
-      val cacheGroups = uniqueConfigs.flatMap(_.cacheGroups) ++ uniqueConfigs.flatMap(_.parameters).flatMap(_.cacheGroups)
-      Future.sequence[(String, CacheGroup), Seq](cacheGroups.toSeq.map(insertCacheGroupIfMissing)).map(_.toMap)
+      val cacheGroups = uniqueConfigs.flatMap(_.cacheGroups) ++
+        uniqueConfigs.flatMap(_.parameters).flatMap(_.cacheGroups)
+      Future.sequence[(String, CacheGroup), Seq](cacheGroups.toSeq.map(insertCacheGroupIfMissing))
+        .map(_.toMap)
     }
 
-    def doImport(): Future[Seq[String]] = Future.sequence[Option[String], Seq](uniqueConfigs.toSeq.map(insertConfigIfMissing)).map(_.flatten)
+    def doImport(): Future[Seq[String]] =
+      Future.sequence[Option[String], Seq](uniqueConfigs.toSeq.map(insertConfigIfMissing))
+        .map(_.flatten)
 
     /**
      * Unconditionally inserts a [[HystrixConfig]], also inserting a [[ThreadPoolConfig]] if necessary
      * @return inserted [[HystrixConfig.id]], or Future.failed with a IllegalArgumentException if a [[HystrixConfig]] with the same [[HystrixConfig.commandKey]] already exists
      */
-    private[repository] def insertHystrixConfig(configId: Long, jHystrixConfig: json.HystrixConfig)(implicit session: DBSession): Future[Long] = {
+    private[repository] def insertHystrixConfig(
+      configId: Long,
+      jHystrixConfig: json.HystrixConfig
+    )(implicit session: DBSession): Future[Long] = {
       fThreadPoolConfigs.flatMap { threadPoolConfigsWithIds =>
         val nakedHystrixConfig = HystrixConfig.fromJsonModel(jHystrixConfig).copy(
           httpPartConfigId = Some(configId),
@@ -79,11 +121,19 @@ trait ConfigImporter {
           threadPoolConfigId = threadPoolConfigsWithIds.get(jHystrixConfig.threadPoolConfig.threadPoolKey),
           threadPoolConfig = None
         )
-        getWithSession(HystrixConfigRepository, sqls.eq(HystrixConfigRepository.defaultAlias.commandKey, nakedHystrixConfig.commandKey)).flatMap {
-          _.fold(saveWithSession(HystrixConfigRepository, nakedHystrixConfig)) {
-            existingHystrixConfig => throw new IllegalArgumentException(s"There is already a HystrixConfig with key=${existingHystrixConfig.commandKey}")
+        getWithSession(
+          HystrixConfigRepository,
+          sqls.eq(HystrixConfigRepository.defaultAlias.commandKey, nakedHystrixConfig.commandKey)
+        ).flatMap {
+            _.fold(
+              saveWithSession(
+                HystrixConfigRepository,
+                nakedHystrixConfig
+              )
+            ) {
+                existingHystrixConfig => throw new IllegalArgumentException(s"There is already a HystrixConfig with key=${existingHystrixConfig.commandKey}")
+              }
           }
-        }
       }
     }
 
@@ -91,7 +141,10 @@ trait ConfigImporter {
      * Inserts a [[PartParam]] and, if necessary, its related [[CacheGroup]]s.
      * @return inserted partParam ID
      */
-    private[repository] def insertPartParam(configId: Long, partParam: json.PartParam)(implicit session: DBSession): Future[Long] = {
+    private[repository] def insertPartParam(
+      configId: Long,
+      partParam: json.PartParam
+    )(implicit session: DBSession): Future[Long] = {
       fCacheGroups.flatMap { cacheGroups =>
         // keep cache groups here
         val nakedPartParam = PartParam.fromJsonModel(partParam).copy(
@@ -107,10 +160,18 @@ trait ConfigImporter {
      * Inserts a [[HttpPartConfig]]
      * @return the [[HttpPartConfig.partId]] if inserted, else [[None]]
      */
-    private[repository] def insertConfigIfMissing(jpart: json.HttpPartConfig)(implicit session: DBSession): Future[Option[String]] = {
-      LTSVLogger.info("part" -> jpart.toString, "action" -> "insert if missing")
+    private[repository] def insertConfigIfMissing(
+      jpart: json.HttpPartConfig
+    )(implicit session: DBSession): Future[Option[String]] = {
+      LTSVLogger.info(
+        "part" -> jpart.toString,
+        "action" -> "insert if missing"
+      )
 
-      val oldConfig = getWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.partId, jpart.partId))
+      val oldConfig = getWithSession(
+        HttpPartConfigRepository,
+        sqls.eq(HttpPartConfigRepository.defaultAlias.partId, jpart.partId)
+      )
       oldConfig.flatMap { mbConfigWasThere =>
         mbConfigWasThere.fold {
           fCacheGroups.flatMap { cacheGroups =>
@@ -130,26 +191,43 @@ trait ConfigImporter {
     /**
      * save and immediately retrieve the new config to get its ID
      */
-    private[repository] def saveAndReturnId(jpart: json.HttpPartConfig, nakedConfig: HttpPartConfig)(implicit session: DBSession): Future[Option[String]] = {
-      saveWithSession(HttpPartConfigRepository, nakedConfig).flatMap {
-        id => getWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.id, id))
+    private[repository] def saveAndReturnId(
+      jpart: json.HttpPartConfig,
+      nakedConfig: HttpPartConfig
+    )(implicit session: DBSession): Future[Option[String]] = {
+      saveWithSession(
+        HttpPartConfigRepository,
+        nakedConfig
+      ).flatMap {
+        id =>
+          getWithSession(
+            HttpPartConfigRepository,
+            sqls.eq(HttpPartConfigRepository.defaultAlias.id, id)
+          )
       }.flatMap { mbInserted =>
         mbInserted.map {
           insertedConfig =>
             // insert dependencies
             val configId = insertedConfig.id.get
-            val fInsertParameters = jpart.parameters.toSeq.map { partParam => insertPartParam(configId, partParam) }
+            val fInsertParameters = jpart.parameters.toSeq
+              .map { partParam => insertPartParam(configId, partParam) }
             // must have a hystrix config
             val fInsertHystrixConfig = insertHystrixConfig(configId, jpart.hystrixConfig)
-            Future.sequence[Long, Seq](fInsertParameters :+ fInsertHystrixConfig).map { _ => Option(insertedConfig.partId) }
+            Future.sequence[Long, Seq](fInsertParameters :+ fInsertHystrixConfig)
+              .map { _ => Option(insertedConfig.partId) }
         }.getOrElse {
-          Future.failed(new IllegalStateException(s"Just inserted a new config ${jpart.partId} but it was not saved!"))
+          Future.failed(new IllegalStateException(
+            s"Just inserted a new config ${jpart.partId} but it was not saved!"
+          ))
         }
       }
     }
   }
 
-  private[repository] def importConfigsWithSession(configs: Seq[json.HttpPartConfig])(implicit session: DBSession = AutoSession) = {
+  private[repository] def importConfigsWithSession(
+    configs: Seq[json.HttpPartConfig]
+  )(implicit session: DBSession = AutoSession) = {
     new ImportAction(configs.to[SortedSet]).doImport()
   }
+
 }

--- a/app/com/m3/octoparts/repository/ConfigImporter.scala
+++ b/app/com/m3/octoparts/repository/ConfigImporter.scala
@@ -77,7 +77,8 @@ trait ConfigImporter {
           httpPartConfigId = Some(configId),
           httpPartConfig = None,
           threadPoolConfigId = threadPoolConfigsWithIds.get(jHystrixConfig.threadPoolConfig.threadPoolKey),
-          threadPoolConfig = None)
+          threadPoolConfig = None
+        )
         getWithSession(HystrixConfigRepository, sqls.eq(HystrixConfigRepository.defaultAlias.commandKey, nakedHystrixConfig.commandKey)).flatMap {
           _.fold(saveWithSession(HystrixConfigRepository, nakedHystrixConfig)) {
             existingHystrixConfig => throw new IllegalArgumentException(s"There is already a HystrixConfig with key=${existingHystrixConfig.commandKey}")

--- a/app/com/m3/octoparts/repository/DBConfigsRepository.scala
+++ b/app/com/m3/octoparts/repository/DBConfigsRepository.scala
@@ -39,11 +39,13 @@ import scala.concurrent.{ ExecutionContext, Future, blocking }
  * In the first case, the session is the globally implicit session
  * The second allows to be explicit (for tests)
  */
-class DBConfigsRepository(zipkinServiceFactory: => ZipkinServiceLike,
-                          protected val executionContext: ExecutionContext)(implicit val metrics: Metrics)
-  extends ImmutableDBRepository
-  with MutableDBRepository
-  with ConfigImporter {
+class DBConfigsRepository(
+  zipkinServiceFactory: => ZipkinServiceLike,
+  protected val executionContext: ExecutionContext
+)(implicit val metrics: Metrics)
+    extends ImmutableDBRepository
+    with MutableDBRepository
+    with ConfigImporter {
 
   implicit lazy val zipkinService: ZipkinServiceLike = zipkinServiceFactory
 }
@@ -171,10 +173,12 @@ trait ImmutableDBRepository extends ConfigsRepository {
   /**
    * Gets a single model from a table according to a where clause and logs the where clause used
    */
-  private[repository] def getWithSession[A](mapper: CRUDFeatureWithId[Long, A],
-                                            where: SQLSyntax,
-                                            joins: Seq[Association[_]] = Nil,
-                                            includes: Seq[Association[_]] = Nil)(implicit session: DBSession = ReadOnlyAutoSession): Future[Option[A]] = Future {
+  private[repository] def getWithSession[A](
+    mapper: CRUDFeatureWithId[Long, A],
+    where: SQLSyntax,
+    joins: Seq[Association[_]] = Nil,
+    includes: Seq[Association[_]] = Nil
+  )(implicit session: DBSession = ReadOnlyAutoSession): Future[Option[A]] = Future {
     blocking {
       val ret = mapper.joins(joins: _*).includes(includes: _*).findBy(where)
       ret.foreach {
@@ -187,9 +191,11 @@ trait ImmutableDBRepository extends ConfigsRepository {
   /**
    * Gets all the records from a table and logs the number of records retrieved
    */
-  private[repository] def getAllWithSession[A: Ordering](mapper: CRUDFeatureWithId[Long, A],
-                                                         joins: Seq[Association[_]] = Nil,
-                                                         includes: Seq[Association[_]] = Nil)(implicit session: DBSession = ReadOnlyAutoSession): Future[SortedSet[A]] =
+  private[repository] def getAllWithSession[A: Ordering](
+    mapper: CRUDFeatureWithId[Long, A],
+    joins: Seq[Association[_]] = Nil,
+    includes: Seq[Association[_]] = Nil
+  )(implicit session: DBSession = ReadOnlyAutoSession): Future[SortedSet[A]] =
     Future {
       blocking {
         val ret = mapper.joins(joins: _*).includes(includes: _*).findAll().to[SortedSet]
@@ -201,10 +207,12 @@ trait ImmutableDBRepository extends ConfigsRepository {
   /**
    * Gets all the records from a table according to a where clause and logs the number of records retrieved
    */
-  private[repository] def getAllByWithSession[A: Ordering](mapper: CRUDFeatureWithId[Long, A],
-                                                           where: SQLSyntax,
-                                                           joins: Seq[Association[_]] = Nil,
-                                                           includes: Seq[Association[_]] = Nil)(implicit session: DBSession = ReadOnlyAutoSession): Future[SortedSet[A]] = Future {
+  private[repository] def getAllByWithSession[A: Ordering](
+    mapper: CRUDFeatureWithId[Long, A],
+    where: SQLSyntax,
+    joins: Seq[Association[_]] = Nil,
+    includes: Seq[Association[_]] = Nil
+  )(implicit session: DBSession = ReadOnlyAutoSession): Future[SortedSet[A]] = Future {
     blocking {
       val ret = mapper.joins(joins: _*).includes(includes: _*).findAllBy(where).to[SortedSet]
       LTSVLogger.debug("Table" -> mapper.tableName, "Retrieved records" -> ret.size.toString)

--- a/app/com/m3/octoparts/repository/DBConfigsRepository.scala
+++ b/app/com/m3/octoparts/repository/DBConfigsRepository.scala
@@ -61,22 +61,32 @@ trait ImmutableDBRepository extends ConfigsRepository {
   private val zipkinSpanNameBase = "db-repo-read"
 
   // Configs
-  def findConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Option[HttpPartConfig]] = {
+  def findConfigByPartId(
+    partId: String
+  )(implicit parentSpan: Span): Future[Option[HttpPartConfig]] = {
     // a hack to set the part parameter cache groups
     // Since there is no reference in the PartParam object, the simplest way is to simply fetch all cache groups.
     // They should be cached anyways.
-    val fMbPartConfig = getWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId), includes = Seq(HttpPartConfigRepository.hystrixConfigRef))
-      .trace(s"$zipkinSpanNameBase-findConfigByPartId", "partId" -> partId)
+    val fMbPartConfig = getWithSession(
+      HttpPartConfigRepository,
+      sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId),
+      includes = Seq(HttpPartConfigRepository.hystrixConfigRef)
+    ).trace(
+        s"$zipkinSpanNameBase-findConfigByPartId",
+        "partId" -> partId
+      )
     val fCacheGroups = findAllCacheGroups()
     for {
       cacheGroups <- fCacheGroups
       mbPartConfig <- fMbPartConfig
     } yield {
-      mbPartConfig.map {
-        config =>
-          config.copy(parameters = config.parameters.map {
-            param => param.copy(cacheGroups = cacheGroups.filter(_.partParams.exists(_.id == param.id)))
-          })
+      mbPartConfig.map { config =>
+        config.copy(parameters = config.parameters.map {
+          param =>
+            param.copy(
+              cacheGroups = cacheGroups.filter(_.partParams.exists(_.id == param.id))
+            )
+        })
       }
     }
   }
@@ -84,67 +94,123 @@ trait ImmutableDBRepository extends ConfigsRepository {
   def findAllConfigs()(implicit parentSpan: Span): Future[SortedSet[HttpPartConfig]] = {
     // a hack to set the part parameter cache groups. see explanation in #findConfigByPartId
     val fCacheGroups = findAllCacheGroups()
-    val fConfigs = getAllWithSession(HttpPartConfigRepository, includes = Seq(HttpPartConfigRepository.hystrixConfigRef))
-      .trace(s"$zipkinSpanNameBase-findAllConfigs")
+    val fConfigs = getAllWithSession(
+      HttpPartConfigRepository,
+      includes = Seq(HttpPartConfigRepository.hystrixConfigRef)
+    ).trace(s"$zipkinSpanNameBase-findAllConfigs")
     for {
       configs <- fConfigs
       allCacheGroups <- fCacheGroups
     } yield {
-      configs.map {
-        config =>
-          config.copy(parameters = config.parameters.map {
-            param => param.copy(cacheGroups = allCacheGroups.filter(_.partParams.exists(_.id == param.id)))
-          })
+      configs.map { config =>
+        config.copy(parameters = config.parameters.map { param =>
+          param.copy(
+            cacheGroups = allCacheGroups.filter(_.partParams.exists(_.id == param.id))
+          )
+        })
       }
     }
   }
 
   def findParamById(id: Long)(implicit parentSpan: Span): Future[Option[PartParam]] = {
-    getWithSession(PartParamRepository, sqls.eq(PartParamRepository.defaultAlias.id, id), joins = Seq(PartParamRepository.httpPartConfigRef, PartParamRepository.cacheGroupsRef))
-      .trace(s"$zipkinSpanNameBase-findParamById", "id" -> id.toString)
+    getWithSession(
+      PartParamRepository,
+      sqls.eq(PartParamRepository.defaultAlias.id, id),
+      joins = Seq(PartParamRepository.httpPartConfigRef, PartParamRepository.cacheGroupsRef)
+    ).trace(
+        s"$zipkinSpanNameBase-findParamById",
+        "id" -> id.toString
+      )
   }
 
   // For ThreadPoolConfigs
   def findThreadPoolConfigById(id: Long)(implicit parentSpan: Span): Future[Option[ThreadPoolConfig]] = {
-    getWithSession(ThreadPoolConfigRepository, sqls.eq(ThreadPoolConfigRepository.defaultAlias.id, id), includes = Seq(ThreadPoolConfigRepository.hystrixConfigRef))
-      .trace(s"$zipkinSpanNameBase-findThreadPoolConfigById", "id" -> id.toString)
+    getWithSession(
+      ThreadPoolConfigRepository,
+      sqls.eq(ThreadPoolConfigRepository.defaultAlias.id, id),
+      includes = Seq(ThreadPoolConfigRepository.hystrixConfigRef)
+    ).trace(
+        s"$zipkinSpanNameBase-findThreadPoolConfigById",
+        "id" -> id.toString
+      )
   }
 
   def findAllThreadPoolConfigs()(implicit parentSpan: Span): Future[SortedSet[ThreadPoolConfig]] = {
-    getAllWithSession(ThreadPoolConfigRepository, includes = Seq(ThreadPoolConfigRepository.hystrixConfigRef))
-      .trace(s"$zipkinSpanNameBase-findAllThreadPoolConfigs")
+    getAllWithSession(
+      ThreadPoolConfigRepository,
+      includes = Seq(ThreadPoolConfigRepository.hystrixConfigRef)
+    ).trace(s"$zipkinSpanNameBase-findAllThreadPoolConfigs")
   }
 
   // For CacheGroups
   def findCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Option[CacheGroup]] = {
     for {
-      mbCacheGroup <- getWithSession(CacheGroupRepository, sqls.eq(CacheGroupRepository.defaultAlias.name, name), joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
-        .trace(s"$zipkinSpanNameBase-findCacheGroupByName", "name" -> name)
-      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = mbCacheGroup.toSeq.map(populateCacheGroupPartParams)
+      mbCacheGroup <- {
+        getWithSession(
+          CacheGroupRepository,
+          sqls.eq(CacheGroupRepository.defaultAlias.name, name),
+          joins = Seq(
+            CacheGroupRepository.httpPartConfigsRef,
+            CacheGroupRepository.partParamsRef
+          )
+        ).trace(
+            s"$zipkinSpanNameBase-findCacheGroupByName",
+            "name" -> name
+          )
+      }
+      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = {
+        mbCacheGroup.toSeq.map(populateCacheGroupPartParams)
+      }
       populatedCacheGroups <- Future.sequence(fPopulateCacheGroupPartParams)
     } yield {
       populatedCacheGroups.headOption
     }
   }
 
-  def findAllCacheGroupsByName(names: String*)(implicit parentSpan: Span): Future[SortedSet[CacheGroup]] = if (names.isEmpty) {
-    Future.successful(SortedSet.empty)
-  } else {
-    for {
-      cacheGroups <- getAllByWithSession(CacheGroupRepository, sqls.in(CacheGroupRepository.defaultAlias.name, names), joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
-        .trace(s"$zipkinSpanNameBase-findAllCacheGroupsByName", "names" -> names.toString)
-      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = cacheGroups.toSeq.map(populateCacheGroupPartParams)
-      populatedCacheGroups <- Future.sequence(fPopulateCacheGroupPartParams)
-    } yield {
-      populatedCacheGroups.to[SortedSet]
+  def findAllCacheGroupsByName(
+    names: String*
+  )(implicit parentSpan: Span): Future[SortedSet[CacheGroup]] = {
+    if (names.isEmpty) {
+      Future.successful(SortedSet.empty)
+    } else {
+      for {
+        cacheGroups <- {
+          getAllByWithSession(
+            CacheGroupRepository,
+            sqls.in(CacheGroupRepository.defaultAlias.name, names),
+            joins = Seq(
+              CacheGroupRepository.httpPartConfigsRef,
+              CacheGroupRepository.partParamsRef
+            )
+          ).trace(
+              s"$zipkinSpanNameBase-findAllCacheGroupsByName",
+              "names" -> names.toString
+            )
+        }
+        fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = {
+          cacheGroups.toSeq.map(populateCacheGroupPartParams)
+        }
+        populatedCacheGroups <- Future.sequence(fPopulateCacheGroupPartParams)
+      } yield {
+        populatedCacheGroups.to[SortedSet]
+      }
     }
   }
 
   def findAllCacheGroups()(implicit parentSpan: Span): Future[SortedSet[CacheGroup]] = {
     for {
-      cacheGroups <- getAllWithSession(CacheGroupRepository, joins = Seq(CacheGroupRepository.httpPartConfigsRef, CacheGroupRepository.partParamsRef))
-        .trace(s"$zipkinSpanNameBase-findAllCacheGroups")
-      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = cacheGroups.toSeq.map(populateCacheGroupPartParams)
+      cacheGroups <- {
+        getAllWithSession(
+          CacheGroupRepository,
+          joins = Seq(
+            CacheGroupRepository.httpPartConfigsRef,
+            CacheGroupRepository.partParamsRef
+          )
+        ).trace(s"$zipkinSpanNameBase-findAllCacheGroups")
+      }
+      fPopulateCacheGroupPartParams: Seq[Future[CacheGroup]] = {
+        cacheGroups.toSeq.map(populateCacheGroupPartParams)
+      }
       populatedCacheGroups <- Future.sequence(fPopulateCacheGroupPartParams)
     } yield {
       populatedCacheGroups.to[SortedSet]
@@ -155,7 +221,9 @@ trait ImmutableDBRepository extends ConfigsRepository {
    * AFAIK the ORM could not be twisted to fetch cacheGroup.partParam.httpPartConfig.
    * This might make 1 request per member, but [[findParamById]] is cached.
    */
-  private def populateCacheGroupPartParams(cacheGroup: CacheGroup)(implicit parentSpan: Span): Future[CacheGroup] = {
+  private def populateCacheGroupPartParams(
+    cacheGroup: CacheGroup
+  )(implicit parentSpan: Span): Future[CacheGroup] = {
     val fOptParams: Seq[Future[Option[PartParam]]] = for {
       partParam <- cacheGroup.partParams.toSeq
       paramId <- partParam.id.toSeq
@@ -182,7 +250,12 @@ trait ImmutableDBRepository extends ConfigsRepository {
     blocking {
       val ret = mapper.joins(joins: _*).includes(includes: _*).findBy(where)
       ret.foreach {
-        ci => LTSVLogger.debug("Table" -> mapper.tableName, "where" -> where.toString(), "Data" -> ret.toString)
+        ci =>
+          LTSVLogger.debug(
+            "Table" -> mapper.tableName,
+            "where" -> where.toString(),
+            "Data" -> ret.toString
+          )
       }
       ret
     }
@@ -199,7 +272,10 @@ trait ImmutableDBRepository extends ConfigsRepository {
     Future {
       blocking {
         val ret = mapper.joins(joins: _*).includes(includes: _*).findAll().to[SortedSet]
-        LTSVLogger.debug("Table" -> mapper.tableName, "Retrieved records" -> ret.size.toString)
+        LTSVLogger.debug(
+          "Table" -> mapper.tableName,
+          "Retrieved records" -> ret.size.toString
+        )
         ret
       }
     }.measure("DB_GET")
@@ -215,7 +291,10 @@ trait ImmutableDBRepository extends ConfigsRepository {
   )(implicit session: DBSession = ReadOnlyAutoSession): Future[SortedSet[A]] = Future {
     blocking {
       val ret = mapper.joins(joins: _*).includes(includes: _*).findAllBy(where).to[SortedSet]
-      LTSVLogger.debug("Table" -> mapper.tableName, "Retrieved records" -> ret.size.toString)
+      LTSVLogger.debug(
+        "Table" -> mapper.tableName,
+        "Retrieved records" -> ret.size.toString
+      )
       ret
     }
   }.measure("DB_GET")
@@ -229,41 +308,75 @@ trait MutableDBRepository extends MutableConfigsRepository {
   implicit def metrics: Metrics
   private val zipkinSpanNameBase = "db-repo-mutation"
 
-  def save[A <: ConfigModel[A]: ConfigMapper](obj: A)(implicit parentSpan: Span): Future[Long] = {
-    DB.futureLocalTx { implicit session => saveWithSession(implicitly[ConfigMapper[A]], obj) }.trace(s"$zipkinSpanNameBase-save", "object" -> obj.toString)
+  def save[A <: ConfigModel[A]: ConfigMapper](
+    obj: A
+  )(implicit parentSpan: Span): Future[Long] = {
+    DB.futureLocalTx { implicit session =>
+      saveWithSession(implicitly[ConfigMapper[A]], obj)
+    }.trace(
+      s"$zipkinSpanNameBase-save",
+      "object" -> obj.toString
+    )
   }
 
   def deleteAllConfigs()(implicit parentSpan: Span): Future[Int] = {
-    deleteAllWithSession(HttpPartConfigRepository).trace(s"$zipkinSpanNameBase-deleteAllConfigs")
+    deleteAllWithSession(HttpPartConfigRepository)
+      .trace(s"$zipkinSpanNameBase-deleteAllConfigs")
   }
 
   def deleteConfigByPartId(partId: String)(implicit parentSpan: Span): Future[Int] = {
-    deleteWithSession(HttpPartConfigRepository, sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId))
-      .trace(s"$zipkinSpanNameBase-deleteConfigByPartId", "partId" -> partId)
+    deleteWithSession(
+      HttpPartConfigRepository,
+      sqls.eq(HttpPartConfigRepository.defaultAlias.partId, partId)
+    ).trace(
+        s"$zipkinSpanNameBase-deleteConfigByPartId",
+        "partId" -> partId
+      )
   }
 
   def deletePartParamById(id: Long)(implicit parentSpan: Span) = {
-    deleteWithSession(PartParamRepository, sqls.eq(PartParamRepository.defaultAlias.id, id))
-      .trace(s"$zipkinSpanNameBase-deletePartParamById", "id" -> id.toString)
+    deleteWithSession(
+      PartParamRepository,
+      sqls.eq(PartParamRepository.defaultAlias.id, id)
+    ).trace(
+        s"$zipkinSpanNameBase-deletePartParamById",
+        "id" -> id.toString
+      )
   }
 
   def deleteThreadPoolConfigById(id: Long)(implicit parentSpan: Span) = {
-    deleteWithSession(ThreadPoolConfigRepository, sqls.eq(ThreadPoolConfigRepository.defaultAlias.id, id))
-      .trace(s"$zipkinSpanNameBase-deleteThreadPoolConfigById", "id" -> id.toString)
+    deleteWithSession(
+      ThreadPoolConfigRepository,
+      sqls.eq(ThreadPoolConfigRepository.defaultAlias.id, id)
+    ).trace(
+        s"$zipkinSpanNameBase-deleteThreadPoolConfigById",
+        "id" -> id.toString
+      )
   }
 
   def deleteCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Int] = {
-    deleteWithSession(CacheGroupRepository, sqls.eq(CacheGroupRepository.defaultAlias.name, name))
-      .trace(s"$zipkinSpanNameBase-deleteCacheGroupByName", "name" -> name)
+    deleteWithSession(
+      CacheGroupRepository,
+      sqls.eq(CacheGroupRepository.defaultAlias.name, name)
+    ).trace(
+        s"$zipkinSpanNameBase-deleteCacheGroupByName",
+        "name" -> name
+      )
   }
 
   /**
    * Saves a model using the mapper passed in, and logs the data that was saved
    */
-  private[repository] def saveWithSession[A <: ConfigModel[A]](mapper: ConfigMapper[A], model: A)(implicit session: DBSession = AutoSession): Future[Long] = Future {
+  private[repository] def saveWithSession[A <: ConfigModel[A]](
+    mapper: ConfigMapper[A], model: A
+  )(implicit session: DBSession = AutoSession): Future[Long] = Future {
     blocking {
       val id = mapper.save(model)
-      LTSVLogger.info("Table" -> mapper.tableName, "Data" -> model.toString, "Action" -> "Saved")
+      LTSVLogger.info(
+        "Table" -> mapper.tableName,
+        "Data" -> model.toString,
+        "Action" -> "Saved"
+      )
       id
     }
   }.measure("DB_UPDATE")
@@ -272,10 +385,18 @@ trait MutableDBRepository extends MutableConfigsRepository {
    * Deletes using a given Skinny CRUD mapper and an interpolated where clause and logs the where
    * clause used.
    */
-  private[repository] def deleteWithSession(mapper: SkinnyCRUDMapper[_], where: SQLSyntax)(implicit session: DBSession = AutoSession): Future[Int] = Future {
+  private[repository] def deleteWithSession(
+    mapper: SkinnyCRUDMapper[_],
+    where: SQLSyntax
+  )(implicit session: DBSession = AutoSession): Future[Int] = Future {
     blocking {
       val count = mapper.deleteBy(where)
-      LTSVLogger.info("Table" -> mapper.tableName, "where" -> where.toString(), "count" -> count.toString, "Action" -> "Deleted")
+      LTSVLogger.info(
+        "Table" -> mapper.tableName,
+        "where" -> where.toString(),
+        "count" -> count.toString,
+        "Action" -> "Deleted"
+      )
       count
     }
   }.measure("DB_UPDATE")
@@ -283,12 +404,18 @@ trait MutableDBRepository extends MutableConfigsRepository {
   /**
    * Truncates a table using the passed in Skinny CRUD mapper and logs how many records were deleted
    */
-  private[repository] def deleteAllWithSession(mapper: SkinnyCRUDMapper[_])(implicit session: DBSession = AutoSession): Future[Int] = Future {
+  private[repository] def deleteAllWithSession(
+    mapper: SkinnyCRUDMapper[_]
+  )(implicit session: DBSession = AutoSession): Future[Int] = Future {
     blocking {
       val count = mapper.deleteAll
-      LTSVLogger.warn("Table" -> mapper.tableName, "count" -> count.toString, "Action" -> "Truncated")
+      LTSVLogger.warn(
+        "Table" -> mapper.tableName,
+        "count" -> count.toString,
+        "Action" -> "Truncated"
+      )
       count
     }
   }.measure("DB_UPDATE")
-}
 
+}

--- a/app/com/m3/octoparts/repository/MutableCachingRepository.scala
+++ b/app/com/m3/octoparts/repository/MutableCachingRepository.scala
@@ -15,8 +15,11 @@ import scala.concurrent.{ ExecutionContext, Future }
 class MutableCachingRepository(
   val delegate: MutableConfigsRepository,
   val cache: Cache,
-  val httpClientPool: HttpClientPool)(
-    implicit val executionContext: ExecutionContext)
+  val httpClientPool: HttpClientPool
+)(
+  implicit
+  val executionContext: ExecutionContext
+)
     extends CachingRepository
     with MutableConfigsRepository {
 

--- a/app/com/m3/octoparts/repository/MutableCachingRepository.scala
+++ b/app/com/m3/octoparts/repository/MutableCachingRepository.scala
@@ -16,14 +16,13 @@ class MutableCachingRepository(
   val delegate: MutableConfigsRepository,
   val cache: Cache,
   val httpClientPool: HttpClientPool
-)(
-  implicit
-  val executionContext: ExecutionContext
-)
+)(implicit val executionContext: ExecutionContext)
     extends CachingRepository
     with MutableConfigsRepository {
 
-  def save[A <: ConfigModel[A]: ConfigMapper](obj: A)(implicit parentSpan: Span): Future[Long] = reloadCacheAfter(delegate.save(obj))
+  def save[A <: ConfigModel[A]: ConfigMapper](
+    obj: A
+  )(implicit parentSpan: Span): Future[Long] = reloadCacheAfter(delegate.save(obj))
 
   def deleteAllConfigs()(implicit parentSpan: Span): Future[Int] = reloadCacheAfter {
     for {
@@ -42,13 +41,17 @@ class MutableCachingRepository(
     } yield deletedCount
   }
 
-  def deleteThreadPoolConfigById(id: Long)(implicit parentSpan: Span): Future[Int] = reloadCacheAfter(delegate.deleteThreadPoolConfigById(id))
+  def deleteThreadPoolConfigById(id: Long)(implicit parentSpan: Span): Future[Int] =
+    reloadCacheAfter(delegate.deleteThreadPoolConfigById(id))
 
-  def deletePartParamById(id: Long)(implicit parentSpan: Span): Future[Int] = reloadCacheAfter(delegate.deletePartParamById(id))
+  def deletePartParamById(id: Long)(implicit parentSpan: Span): Future[Int] =
+    reloadCacheAfter(delegate.deletePartParamById(id))
 
-  def deleteCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Int] = reloadCacheAfter(delegate.deleteCacheGroupByName(name))
+  def deleteCacheGroupByName(name: String)(implicit parentSpan: Span): Future[Int] =
+    reloadCacheAfter(delegate.deleteCacheGroupByName(name))
 
-  def importConfigs(configs: Seq[json.HttpPartConfig])(implicit parentSpan: Span): Future[Seq[String]] = reloadCacheAfter(delegate.importConfigs(configs))
+  def importConfigs(configs: Seq[json.HttpPartConfig])(implicit parentSpan: Span): Future[Seq[String]] =
+    reloadCacheAfter(delegate.importConfigs(configs))
 
   private def reloadCacheAfter[A](f: => Future[A])(implicit parentSpan: Span) = {
     for {

--- a/app/com/m3/octoparts/repository/config/CacheGroupRepository.scala
+++ b/app/com/m3/octoparts/repository/config/CacheGroupRepository.scala
@@ -37,12 +37,12 @@ object CacheGroupRepository extends ConfigMapper[CacheGroup] with TimestampsFeat
     manyFk = "httpPartConfigId",
     merge = (group, partConfigs) => group.copy(httpPartConfigs = partConfigs.to[SortedSet])
   ).includes[HttpPartConfig] {
-      (cacheGroups, partConfigs) =>
-        cacheGroups.map {
-          cacheGroup =>
-            cacheGroup.copy(httpPartConfigs = partConfigs.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet])
-        }
-    } // DO NOT tack on .byDefault here
+    (cacheGroups, partConfigs) =>
+      cacheGroups.map {
+        cacheGroup =>
+          cacheGroup.copy(httpPartConfigs = partConfigs.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet])
+      }
+  } // DO NOT tack on .byDefault here
 
   // We need to use this verbose form to help SkinnyORM NOT to bump into weird table alias collision errors
   lazy val partParamsRef: HasManyAssociation[CacheGroup] = hasManyThrough[PartParamCacheGroup, PartParam](
@@ -52,12 +52,12 @@ object CacheGroupRepository extends ConfigMapper[CacheGroup] with TimestampsFeat
     on = (m1: Alias[PartParamCacheGroup], m2: Alias[PartParam]) => sqls.eq(m1.partParamId, m2.id),
     merge = (cacheGroup, params) => cacheGroup.copy(partParams = params.to[SortedSet])
   ).includes[PartParam] {
-      (cacheGroups, partParams) =>
-        cacheGroups.map {
-          cacheGroup =>
-            cacheGroup.copy(partParams = partParams.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet])
-        }
-    }
+    (cacheGroups, partParams) =>
+      cacheGroups.map {
+        cacheGroup =>
+          cacheGroup.copy(partParams = partParams.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet])
+      }
+  }
 
   /**
    * Shortcut for retrieving CacheGroups along with children

--- a/app/com/m3/octoparts/repository/config/CacheGroupRepository.scala
+++ b/app/com/m3/octoparts/repository/config/CacheGroupRepository.scala
@@ -9,7 +9,9 @@ import skinny.{ ParamType => SkinnyParamType }
 
 import scala.collection.SortedSet
 
-object CacheGroupRepository extends ConfigMapper[CacheGroup] with TimestampsFeature[CacheGroup] {
+object CacheGroupRepository
+    extends ConfigMapper[CacheGroup]
+    with TimestampsFeature[CacheGroup] {
 
   protected val permittedFields = Seq(
     "owner" -> SkinnyParamType.String,
@@ -36,12 +38,12 @@ object CacheGroupRepository extends ConfigMapper[CacheGroup] with TimestampsFeat
     throughFk = "cacheGroupId",
     manyFk = "httpPartConfigId",
     merge = (group, partConfigs) => group.copy(httpPartConfigs = partConfigs.to[SortedSet])
-  ).includes[HttpPartConfig] {
-    (cacheGroups, partConfigs) =>
-      cacheGroups.map {
-        cacheGroup =>
-          cacheGroup.copy(httpPartConfigs = partConfigs.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet])
-      }
+  ).includes[HttpPartConfig] { (cacheGroups, partConfigs) =>
+    cacheGroups.map { cacheGroup =>
+      cacheGroup.copy(
+        httpPartConfigs = partConfigs.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet]
+      )
+    }
   } // DO NOT tack on .byDefault here
 
   // We need to use this verbose form to help SkinnyORM NOT to bump into weird table alias collision errors
@@ -51,12 +53,12 @@ object CacheGroupRepository extends ConfigMapper[CacheGroup] with TimestampsFeat
     many = PartParamRepository -> PartParamRepository.createAlias("partParamJoin2"),
     on = (m1: Alias[PartParamCacheGroup], m2: Alias[PartParam]) => sqls.eq(m1.partParamId, m2.id),
     merge = (cacheGroup, params) => cacheGroup.copy(partParams = params.to[SortedSet])
-  ).includes[PartParam] {
-    (cacheGroups, partParams) =>
-      cacheGroups.map {
-        cacheGroup =>
-          cacheGroup.copy(partParams = partParams.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet])
-      }
+  ).includes[PartParam] { (cacheGroups, partParams) =>
+    cacheGroups.map { cacheGroup =>
+      cacheGroup.copy(
+        partParams = partParams.filter(_.cacheGroups.map(_.id).contains(cacheGroup.id)).to[SortedSet]
+      )
+    }
   }
 
   /**

--- a/app/com/m3/octoparts/repository/config/HttpPartConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HttpPartConfigRepository.scala
@@ -91,7 +91,11 @@ object HttpPartConfigRepository extends ConfigMapper[HttpPartConfig] with Timest
     on = (c, p) => sqls.eq(c.id, p.httpPartConfigId),
     // function to merge associations to main entity
     merge = (c, params) => c.copy(parameters = params.to[SortedSet])
-  ).includes[PartParam]((hs, params) => hs.map(h => h.copy(parameters = params.filter(_.httpPartConfigId == h.id).to[SortedSet])))
+  ).includes[PartParam] { (hs, params) =>
+    hs.map(h => h.copy(
+      parameters = params.filter(_.httpPartConfigId == h.id).to[SortedSet]
+    ))
+  }
 
   /*
     References the collection of CacheGroups that each HttpPartConfig has; note that you cannot
@@ -100,13 +104,14 @@ object HttpPartConfigRepository extends ConfigMapper[HttpPartConfig] with Timest
 
     See https://github.com/skinny-framework/skinny-framework/commit/13a87c7a3f671c3c77535426ead117cf15e431a9
    */
-  lazy val cacheGroupsRef: HasManyAssociation[HttpPartConfig] = hasManyThrough[HttpPartConfigCacheGroup, CacheGroup](
-    through = HttpPartConfigCacheGroupRepository -> HttpPartConfigCacheGroupRepository.createAlias("httpPartTestGroupJoin"),
-    throughOn = (m1: Alias[HttpPartConfig], m2: Alias[HttpPartConfigCacheGroup]) => sqls.eq(m1.id, m2.httpPartConfigId),
-    many = CacheGroupRepository -> CacheGroupRepository.createAlias("cacheGroupJoin"),
-    on = (m1: Alias[HttpPartConfigCacheGroup], m2: Alias[CacheGroup]) => sqls.eq(m1.cacheGroupId, m2.id),
-    merge = (part, cacheGroups) => part.copy(cacheGroups = cacheGroups.to[SortedSet])
-  )
+  lazy val cacheGroupsRef: HasManyAssociation[HttpPartConfig] =
+    hasManyThrough[HttpPartConfigCacheGroup, CacheGroup](
+      through = HttpPartConfigCacheGroupRepository -> HttpPartConfigCacheGroupRepository.createAlias("httpPartTestGroupJoin"),
+      throughOn = (m1: Alias[HttpPartConfig], m2: Alias[HttpPartConfigCacheGroup]) => sqls.eq(m1.id, m2.httpPartConfigId),
+      many = CacheGroupRepository -> CacheGroupRepository.createAlias("cacheGroupJoin"),
+      on = (m1: Alias[HttpPartConfigCacheGroup], m2: Alias[CacheGroup]) => sqls.eq(m1.cacheGroupId, m2.id),
+      merge = (part, cacheGroups) => part.copy(cacheGroups = cacheGroups.to[SortedSet])
+    )
 
   /*
    This is the magic hasOne+includes definition that allows us to fetch a HttpPartConfig's HystrixConfig AND its
@@ -116,9 +121,13 @@ object HttpPartConfigRepository extends ConfigMapper[HttpPartConfig] with Timest
     right = HystrixConfigRepository,
     fk = "httpPartConfigId",
     merge = (c, hc) => c.copy(hystrixConfig = hc)
-  ).includes[HystrixConfig](
-    merge = (cs, hs) => cs.map { c => c.copy(hystrixConfig = hs.find(_.httpPartConfigId == c.id)) }
-  )
+  ).includes[HystrixConfig] { (cs, hs) =>
+    cs.map { c =>
+      c.copy(
+        hystrixConfig = hs.find(_.httpPartConfigId == c.id)
+      )
+    }
+  }
 
   // initializes the default references
   {

--- a/app/com/m3/octoparts/repository/config/HttpPartConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HttpPartConfigRepository.scala
@@ -117,8 +117,8 @@ object HttpPartConfigRepository extends ConfigMapper[HttpPartConfig] with Timest
     fk = "httpPartConfigId",
     merge = (c, hc) => c.copy(hystrixConfig = hc)
   ).includes[HystrixConfig](
-      merge = (cs, hs) => cs.map { c => c.copy(hystrixConfig = hs.find(_.httpPartConfigId == c.id)) }
-    )
+    merge = (cs, hs) => cs.map { c => c.copy(hystrixConfig = hs.find(_.httpPartConfigId == c.id)) }
+  )
 
   // initializes the default references
   {

--- a/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
@@ -26,7 +26,8 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
   // #byDefault is used for now in case we ever need to refer back to the HttpPartConfig
   // to which this HystrixConfig belongs
   lazy val httpPartConfigOpt = belongsToWithFk[HttpPartConfig](
-    HttpPartConfigRepository, "httpPartConfigId", (hc, mbHpc) => hc.copy(httpPartConfig = mbHpc))
+    HttpPartConfigRepository, "httpPartConfigId", (hc, mbHpc) => hc.copy(httpPartConfig = mbHpc)
+  )
 
   /*
     #byDefault should always be used here because we need to be able to eager load the thread
@@ -36,12 +37,11 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
     belongsToWithFk[ThreadPoolConfig](
       ThreadPoolConfigRepository, "threadPoolConfigId", (h, c) => h.copy(threadPoolConfig = c)
     ).includes[ThreadPoolConfig](merge = (hystrixConfigs, threadConfigs) =>
-        hystrixConfigs.map { h =>
-          threadConfigs.collectFirst {
-            case tpc if h.threadPoolConfigId == tpc.id => h.copy(threadPoolConfig = Some(tpc))
-          }.getOrElse(h)
-        }
-      )
+      hystrixConfigs.map { h =>
+        threadConfigs.collectFirst {
+          case tpc if h.threadPoolConfigId == tpc.id => h.copy(threadPoolConfig = Some(tpc))
+        }.getOrElse(h)
+      })
   }
 
   // initializes the default references
@@ -59,5 +59,6 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
     timeout = rs.long(n.timeout).millis,
     localContentsAsFallback = rs.get(n.localContentsAsFallback),
     createdAt = rs.get(n.createdAt),
-    updatedAt = rs.get(n.updatedAt))
+    updatedAt = rs.get(n.updatedAt)
+  )
 }

--- a/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/HystrixConfigRepository.scala
@@ -8,7 +8,9 @@ import skinny.{ ParamType => SkinnyParamType }
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with TimestampsFeature[HystrixConfig] {
+object HystrixConfigRepository
+    extends ConfigMapper[HystrixConfig]
+    with TimestampsFeature[HystrixConfig] {
 
   override lazy val defaultAlias = createAlias("hystrix_config")
 
@@ -35,13 +37,17 @@ object HystrixConfigRepository extends ConfigMapper[HystrixConfig] with Timestam
   */
   lazy val threadConfigOpt = {
     belongsToWithFk[ThreadPoolConfig](
-      ThreadPoolConfigRepository, "threadPoolConfigId", (h, c) => h.copy(threadPoolConfig = c)
-    ).includes[ThreadPoolConfig](merge = (hystrixConfigs, threadConfigs) =>
+      right = ThreadPoolConfigRepository,
+      fk = "threadPoolConfigId",
+      merge = (h, c) => h.copy(threadPoolConfig = c)
+    ).includes[ThreadPoolConfig] { (hystrixConfigs, threadConfigs) =>
       hystrixConfigs.map { h =>
         threadConfigs.collectFirst {
-          case tpc if h.threadPoolConfigId == tpc.id => h.copy(threadPoolConfig = Some(tpc))
+          case tpc if h.threadPoolConfigId == tpc.id =>
+            h.copy(threadPoolConfig = Some(tpc))
         }.getOrElse(h)
-      })
+      }
+    }
   }
 
   // initializes the default references

--- a/app/com/m3/octoparts/repository/config/PartParamRepository.scala
+++ b/app/com/m3/octoparts/repository/config/PartParamRepository.scala
@@ -8,7 +8,9 @@ import skinny.{ ParamType => SkinnyParamType }
 
 import scala.collection.SortedSet
 
-object PartParamRepository extends ConfigMapper[PartParam] with TimestampsFeature[PartParam] {
+object PartParamRepository
+    extends ConfigMapper[PartParam]
+    with TimestampsFeature[PartParam] {
 
   lazy val defaultAlias = createAlias("part_param")
 
@@ -56,11 +58,13 @@ object PartParamRepository extends ConfigMapper[PartParam] with TimestampsFeatur
     throughFk = "partParamId",
     manyFk = "cacheGroupId",
     merge = (param, cacheGroups) => param.copy(cacheGroups = cacheGroups.to[SortedSet])
-  ).includes[CacheGroup](
-    (params, cacheGroups) => params.map { param =>
-      param.copy(cacheGroups = cacheGroups.filter(_.partParams.exists(_.id == param.id)).to[SortedSet])
+  ).includes[CacheGroup] { (params, cacheGroups) =>
+    params.map { param =>
+      param.copy(
+        cacheGroups = cacheGroups.filter(_.partParams.exists(_.id == param.id)).to[SortedSet]
+      )
     }
-  )
+  }
 
   // initializes the default references
   {

--- a/app/com/m3/octoparts/repository/config/PartParamRepository.scala
+++ b/app/com/m3/octoparts/repository/config/PartParamRepository.scala
@@ -57,10 +57,10 @@ object PartParamRepository extends ConfigMapper[PartParam] with TimestampsFeatur
     manyFk = "cacheGroupId",
     merge = (param, cacheGroups) => param.copy(cacheGroups = cacheGroups.to[SortedSet])
   ).includes[CacheGroup](
-      (params, cacheGroups) => params.map { param =>
-        param.copy(cacheGroups = cacheGroups.filter(_.partParams.exists(_.id == param.id)).to[SortedSet])
-      }
-    )
+    (params, cacheGroups) => params.map { param =>
+      param.copy(cacheGroups = cacheGroups.filter(_.partParams.exists(_.id == param.id)).to[SortedSet])
+    }
+  )
 
   // initializes the default references
   {

--- a/app/com/m3/octoparts/repository/config/ThreadPoolConfigRepository.scala
+++ b/app/com/m3/octoparts/repository/config/ThreadPoolConfigRepository.scala
@@ -7,7 +7,9 @@ import skinny.{ ParamType => SkinnyParamType }
 
 import scala.collection.SortedSet
 
-object ThreadPoolConfigRepository extends ConfigMapper[ThreadPoolConfig] with TimestampsFeature[ThreadPoolConfig] {
+object ThreadPoolConfigRepository
+    extends ConfigMapper[ThreadPoolConfig]
+    with TimestampsFeature[ThreadPoolConfig] {
 
   lazy val defaultAlias = createAlias("thread_pool_config")
 
@@ -25,7 +27,11 @@ object ThreadPoolConfigRepository extends ConfigMapper[ThreadPoolConfig] with Ti
     on = (t, h) => sqls.eq(t.id, h.threadPoolConfigId),
     // function to merge associations to main entity
     merge = (tpc, hcs) => tpc.copy(hystrixConfigs = hcs.toSet)
-  ).includes[HystrixConfig]((tpcs, hcs) => tpcs.map(tpc => tpc.copy(hystrixConfigs = hcs.filter(_.threadPoolConfigId == tpc.id).toSet)))
+  ).includes[HystrixConfig] { (tpcs, hcs) =>
+    tpcs.map(tpc => tpc.copy(
+      hystrixConfigs = hcs.filter(_.threadPoolConfigId == tpc.id).toSet
+    ))
+  }
 
   def extract(rs: WrappedResultSet, n: ResultName[ThreadPoolConfig]) = ThreadPoolConfig(
     id = rs.get(n.id),

--- a/app/com/m3/octoparts/util/OctoMetricsImpl.scala
+++ b/app/com/m3/octoparts/util/OctoMetricsImpl.scala
@@ -14,7 +14,10 @@ import scala.util.control.NonFatal
  * This implementation of Metrics overrides onStart to perform onStop cleanups first before proceeding with
  * other onStart duties
  */
-class OctoMetricsImpl(lifecycle: ApplicationLifecycle, configuration: Configuration) extends MetricsImpl(lifecycle, configuration) {
+class OctoMetricsImpl(
+    lifecycle: ApplicationLifecycle,
+    configuration: Configuration
+) extends MetricsImpl(lifecycle, configuration) {
 
   override def onStart(): ObjectMapper = {
     try {

--- a/app/com/m3/octoparts/wiring/AggregatorServicesModule.scala
+++ b/app/com/m3/octoparts/wiring/AggregatorServicesModule.scala
@@ -4,7 +4,10 @@ import scala.concurrent.duration._
 import com.m3.octoparts.aggregator.service.{ PartsService, PartResponseLocalContentSupport, PartRequestService }
 import com.m3.octoparts.cache.PartResponseCachingSupport
 
-trait AggregatorServicesModule extends RepositoriesModule with AggregatorHandlersModule with ExecutionContextsModule { module =>
+trait AggregatorServicesModule
+    extends RepositoriesModule
+    with AggregatorHandlersModule
+    with ExecutionContextsModule { module =>
 
   private implicit lazy val ec = partsServiceContext
 

--- a/app/com/m3/octoparts/wiring/CacheModule.scala
+++ b/app/com/m3/octoparts/wiring/CacheModule.scala
@@ -24,7 +24,8 @@ trait CacheModule extends UtilsModule {
     val queue: BlockingQueue[Runnable] = new ArrayBlockingQueue[Runnable](queueSize)
 
     ExecutionContext.fromExecutor(
-      new ThreadPoolExecutor(0, poolSize, 1L, TimeUnit.MINUTES, queue, namedThreadFactory))
+      new ThreadPoolExecutor(0, poolSize, 1L, TimeUnit.MINUTES, queue, namedThreadFactory)
+    )
   }
 
   lazy val latestVersionCache = {
@@ -58,7 +59,8 @@ trait CacheModule extends UtilsModule {
           protocol = Protocol.withName(protocol),
           authentication = auth,
           failureMode = FailureMode.Redistribute
-        ))(cacheExecutor)
+        )
+      )(cacheExecutor)
 
       new LoggingRawCache(new MemcachedRawCache(shade))(cacheExecutor)
     }

--- a/app/com/m3/octoparts/wiring/OctopartsApplicationLoader.scala
+++ b/app/com/m3/octoparts/wiring/OctopartsApplicationLoader.scala
@@ -4,7 +4,9 @@ import com.m3.octoparts.wiring.assembling.{ ApplicationComponents, BeforeStartup
 import play.api.ApplicationLoader.Context
 import play.api._
 
-class OctopartsApplicationLoader extends ApplicationLoader with BeforeStartupSupport {
+class OctopartsApplicationLoader
+    extends ApplicationLoader
+    with BeforeStartupSupport {
 
   def load(context: Context): Application = {
     val appComponents = components(context)

--- a/app/com/m3/octoparts/wiring/RepositoriesModule.scala
+++ b/app/com/m3/octoparts/wiring/RepositoriesModule.scala
@@ -5,7 +5,10 @@ import com.m3.octoparts.cache.memcached.MemcachedCache
 import com.m3.octoparts.repository.{ DBConfigsRepository, MutableCachingRepository }
 import scala.concurrent.duration._
 
-trait RepositoriesModule extends CacheModule with HttpClientPoolModule with ExecutionContextsModule {
+trait RepositoriesModule
+    extends CacheModule
+    with HttpClientPoolModule
+    with ExecutionContextsModule {
 
   import com.softwaremill.macwire._
 

--- a/app/com/m3/octoparts/wiring/assembling/EnvConfigLoader.scala
+++ b/app/com/m3/octoparts/wiring/assembling/EnvConfigLoader.scala
@@ -9,7 +9,10 @@ trait EnvConfigLoader {
    * Based on the current config, loads properties/config from an env-specific application.$env.conf file,
    * combining it with the passed-in config
    */
-  protected def withEnvConfig(baseConfig: Configuration, environment: Environment): Configuration = {
+  protected def withEnvConfig(
+    baseConfig: Configuration,
+    environment: Environment
+  ): Configuration = {
     val mode = environment.mode
     val playEnv = baseConfig.getString("application.env").fold(mode.toString.toLowerCase) { parsedEnv =>
       /* "test" mode should cause the environment to be "test" except when
@@ -31,7 +34,10 @@ trait EnvConfigLoader {
     }
   }
 
-  protected def configFileResolvable(configFileName: String, env: Environment): Boolean = {
+  protected def configFileResolvable(
+    configFileName: String,
+    env: Environment
+  ): Boolean = {
     Option(env.classLoader.getResource(configFileName)).isDefined
   }
 

--- a/app/com/m3/octoparts/wiring/assembling/SwaggerScanSupport.scala
+++ b/app/com/m3/octoparts/wiring/assembling/SwaggerScanSupport.scala
@@ -21,7 +21,11 @@ trait SwaggerScanSupport {
    * Initiates Swagger
    */
   protected def initSwagger(components: ApplicationComponents): Unit = {
-    val scanner = new SwaggerScanner(components.router, components.application, components.applicationLifecycle)
+    val scanner = new SwaggerScanner(
+      components.router,
+      components.application,
+      components.applicationLifecycle
+    )
     scanner.scan()
   }
 
@@ -31,7 +35,11 @@ trait SwaggerScanSupport {
  * Ghetto version of [[pl.matisoft.swagger.SwaggerPluginProvider]] without dependence on
  * injection
  */
-class SwaggerScanner(router: Router, app: Application, lifecycle: ApplicationLifecycle) {
+class SwaggerScanner(
+    router: Router,
+    app: Application,
+    lifecycle: ApplicationLifecycle
+) {
 
   val logger = Logger("swagger")
 

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -28,10 +28,12 @@ import scala.concurrent.Future
 import scala.util.{ Success, Failure, Try }
 import scala.util.control.NonFatal
 
-class AdminController(cacheOps: CacheOps,
-                      repository: MutableConfigsRepository,
-                      val authHandler: Option[OctopartsAuthHandler],
-                      val messagesApi: MessagesApi)(implicit val navbarLinks: NavbarLinks)
+class AdminController(
+  cacheOps: CacheOps,
+  repository: MutableConfigsRepository,
+  val authHandler: Option[OctopartsAuthHandler],
+  val messagesApi: MessagesApi
+)(implicit val navbarLinks: NavbarLinks)
     extends Controller
     with AuthSupport
     with LoggingSupport
@@ -263,7 +265,8 @@ class AdminController(cacheOps: CacheOps,
             description = data.description.filterNot(_.isEmpty),
             cacheGroups = cacheGroups,
             createdAt = DateTime.now,
-            updatedAt = DateTime.now)
+            updatedAt = DateTime.now
+          )
           saveAndRedirect {
             saveParamAndClearPartResponseCache(partId, param)
           }(routes.AdminController.newParam(partId), id => routes.AdminController.showPart(partId))
@@ -289,7 +292,8 @@ class AdminController(cacheOps: CacheOps,
               inputNameOverride = data.inputNameOverride.filterNot(_.isEmpty),
               description = data.description.filterNot(_.isEmpty),
               cacheGroups = cacheGroups,
-              updatedAt = DateTime.now)
+              updatedAt = DateTime.now
+            )
             saveAndRedirect {
               saveParamAndClearPartResponseCache(partId, newParam)
             }(routes.AdminController.editParam(partId, paramId), _ => routes.AdminController.showPart(partId))

--- a/app/controllers/AdminForms.scala
+++ b/app/controllers/AdminForms.scala
@@ -36,7 +36,10 @@ object AdminForms {
     data =>
 
     /** Create a brand new HttpPartConfig using the data input into the form */
-    def toNewHttpPartConfig(owner: String, cacheGroups: SortedSet[CacheGroup]): HttpPartConfig = HttpPartConfig(
+    def toNewHttpPartConfig(
+      owner: String,
+      cacheGroups: SortedSet[CacheGroup]
+    ): HttpPartConfig = HttpPartConfig(
       partId = PartData.trimPartId(data.partId),
       owner = owner,
       description = data.description,
@@ -72,7 +75,10 @@ object AdminForms {
     )
 
     /** Update an existing HttpPartConfig using the data input into the form */
-    def toUpdatedHttpPartConfig(originalPart: HttpPartConfig, cacheGroups: SortedSet[CacheGroup]): HttpPartConfig = originalPart.copy(
+    def toUpdatedHttpPartConfig(
+      originalPart: HttpPartConfig,
+      cacheGroups: SortedSet[CacheGroup]
+    ): HttpPartConfig = originalPart.copy(
       partId = PartData.trimPartId(data.partId),
       description = data.description,
       uriToInterpolate = data.httpSettings.uri,
@@ -147,7 +153,11 @@ object AdminForms {
     private def trimPartId(original: String): String = {
       val trimmed = StringUtils.strip(original)
       if (trimmed != original) {
-        LTSVLogger.info("message" -> "Leading and trailing spaces were trimmed from partId", "before" -> s"'$original'", "after" -> s"'$trimmed'")
+        LTSVLogger.info(
+          "message" -> "Leading and trailing spaces were trimmed from partId",
+          "before" -> s"'$original'",
+          "after" -> s"'$trimmed'"
+        )
       }
       trimmed
     }

--- a/app/controllers/AdminForms.scala
+++ b/app/controllers/AdminForms.scala
@@ -14,11 +14,13 @@ import scala.concurrent.duration._
 
 object AdminForms {
 
-  case class AlertMailData(enabled: Boolean,
-                           interval: Option[Int],
-                           absoluteThreshold: Option[Int],
-                           percentThreshold: Option[BigDecimal],
-                           recipients: Option[String])
+  case class AlertMailData(
+    enabled: Boolean,
+    interval: Option[Int],
+    absoluteThreshold: Option[Int],
+    percentThreshold: Option[BigDecimal],
+    recipients: Option[String]
+  )
 
   case class PartData(
       partId: String,
@@ -29,7 +31,8 @@ object AdminForms {
       ttl: Option[Int],
       cacheGroupNames: Seq[String],
       alertMailData: AlertMailData,
-      localContentsConfig: LocalContentsConfig) {
+      localContentsConfig: LocalContentsConfig
+  ) {
     data =>
 
     /** Create a brand new HttpPartConfig using the data input into the form */
@@ -117,7 +120,8 @@ object AdminForms {
         httpConnectionTimeoutInMs = part.httpConnectionTimeout.toMillis.toInt,
         httpSocketTimeoutInMs = part.httpSocketTimeout.toMillis.toInt,
         httpDefaultEncoding = part.httpDefaultEncoding.name,
-        httpProxy = part.httpProxy),
+        httpProxy = part.httpProxy
+      ),
       hystrixConfig = HystrixConfigData(
         commandKey = part.hystrixConfigItem.commandKey,
         commandGroupKey = part.hystrixConfigItem.commandGroupKey,
@@ -136,7 +140,8 @@ object AdminForms {
       ),
       localContentsConfig = LocalContentsConfig(
         enabled = part.localContentsEnabled,
-        contents = part.localContents)
+        contents = part.localContents
+      )
     )
 
     private def trimPartId(original: String): String = {
@@ -189,7 +194,8 @@ object AdminForms {
 
   case class LocalContentsConfig(
     enabled: Boolean,
-    contents: Option[String])
+    contents: Option[String]
+  )
 
   case class HttpConfigData(
     uri: String,
@@ -199,14 +205,16 @@ object AdminForms {
     httpConnectionTimeoutInMs: Int,
     httpSocketTimeoutInMs: Int,
     httpDefaultEncoding: String,
-    httpProxy: Option[String])
+    httpProxy: Option[String]
+  )
 
   case class HystrixConfigData(
     commandKey: String,
     commandGroupKey: String,
     timeoutInMs: Int,
     threadPoolConfigId: Long,
-    localContentsAsFallback: Boolean)
+    localContentsAsFallback: Boolean
+  )
 
   case class ParamData(
     outputName: String,
@@ -215,7 +223,8 @@ object AdminForms {
     paramType: String,
     required: Boolean,
     versioned: Boolean,
-    cacheGroupNames: Seq[String])
+    cacheGroupNames: Seq[String]
+  )
 
   val paramForm = Form(
     mapping(

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -10,7 +10,10 @@ import play.api.mvc.{ Action, Controller }
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-class AuthController(val authHandler: Option[OctopartsAuthHandler]) extends Controller with AuthSupport {
+class AuthController(
+  val authHandler: Option[OctopartsAuthHandler]
+) extends Controller
+    with AuthSupport {
 
   import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
@@ -18,7 +21,9 @@ class AuthController(val authHandler: Option[OctopartsAuthHandler]) extends Cont
     val redirect = Redirect(routes.AdminController.listParts)
     authHandler.fold {
       // No enabled auth plugin, so do the default behaviour, i.e. delete the Principal from Play session
-      Future.successful(PrincipalSessionPersistence.deletePrincipalFromPlaySession(request, redirect))
+      Future.successful(
+        PrincipalSessionPersistence.deletePrincipalFromPlaySession(request, redirect)
+      )
     } { plugin =>
       // Let the plugin take care of it
       plugin.onLogout(request, redirect)
@@ -30,14 +35,24 @@ class AuthController(val authHandler: Option[OctopartsAuthHandler]) extends Cont
       // No enabled auth plugin. Just redirect to the the original URL
       Future.successful(Redirect(origUrl))
     } { plugin =>
-      plugin.onAuthenticationCallback(request).flatMap { principal =>
-        LTSVLogger.debug("Authentication completed for" -> principal.nickname, "Redirecting to" -> origUrl)
-        plugin.savePrincipal(request, Redirect(origUrl), principal)
-      }.recover {
-        case NonFatal(e) =>
-          LTSVLogger.warn(e, "Authentication failed for request" -> request, "request id" -> request.id, "request headers" -> request.headers)
-          InternalServerError(s"Authentication failed: ${e.getMessage}")
-      }
+      plugin.onAuthenticationCallback(request)
+        .flatMap { principal =>
+          LTSVLogger.debug(
+            "Authentication completed for" -> principal.nickname,
+            "Redirecting to" -> origUrl
+          )
+          plugin.savePrincipal(request, Redirect(origUrl), principal)
+        }
+        .recover {
+          case NonFatal(e) =>
+            LTSVLogger.warn(
+              e,
+              "Authentication failed for request" -> request,
+              "request id" -> request.id,
+              "request headers" -> request.headers
+            )
+            InternalServerError(s"Authentication failed: ${e.getMessage}")
+        }
     }
   }
 

--- a/app/controllers/CacheController.scala
+++ b/app/controllers/CacheController.scala
@@ -35,7 +35,8 @@ class CacheController(cacheOps: CacheOps, repository: ConfigsRepository)
     httpMethod = "POST"
   )
   def invalidatePart(
-    @ApiParam(value = "The id of the endpoint that you wish to invalidate", required = true)@PathParam("partId") partId: String) = Action.async { implicit request =>
+    @ApiParam(value = "The id of the endpoint that you wish to invalidate", required = true)@PathParam("partId") partId: String
+  ) = Action.async { implicit request =>
     // TODO could check if part exists and return a 404 if not
     debugRc("action" -> "invalidateAll", "partId" -> partId)
     checkResult(cacheOps.increasePartVersion(partId))
@@ -51,7 +52,8 @@ class CacheController(cacheOps: CacheOps, repository: ConfigsRepository)
   def invalidatePartParam(
     @ApiParam(value = "The id of the endpoint that you wish to invalidate", required = true)@PathParam("partId") partId: String,
     @ApiParam(value = "The parameter name that you wish to invalidate with", required = true)@PathParam("paramName") paramName: String,
-    @ApiParam(value = "The specific parameter value that you wish to invalidate by", required = true)@PathParam("paramValue") paramValue: String) = Action.async { implicit request =>
+    @ApiParam(value = "The specific parameter value that you wish to invalidate by", required = true)@PathParam("paramValue") paramValue: String
+  ) = Action.async { implicit request =>
     // TODO could check if part exists and return a 404 if not
     debugRc("action" -> "invalidateAll", "partId" -> partId, "pname" -> paramName, "pvalue" -> paramValue)
     checkResult(cacheOps.increaseParamVersion(VersionedParamKey(partId, paramName, paramValue)))
@@ -66,7 +68,8 @@ class CacheController(cacheOps: CacheOps, repository: ConfigsRepository)
   )
   @ApiResponses(Array(new ApiResponse(code = 404, message = "Cache group not found")))
   def invalidateCacheGroupParts(
-    @ApiParam(value = "The name of the CacheGroup that you wish to invalidate", required = true)@PathParam("cacheGroupName") cacheGroupName: String) = Action.async { implicit request =>
+    @ApiParam(value = "The name of the CacheGroup that you wish to invalidate", required = true)@PathParam("cacheGroupName") cacheGroupName: String
+  ) = Action.async { implicit request =>
     val fMaybeCacheGroup = repository.findCacheGroupByName(cacheGroupName)
     fMaybeCacheGroup.flatMap[Result] { maybeCacheGroup =>
       maybeCacheGroup.fold {
@@ -88,7 +91,8 @@ class CacheController(cacheOps: CacheOps, repository: ConfigsRepository)
   @ApiResponses(Array(new ApiResponse(code = 404, message = "Cache group not found")))
   def invalidateCacheGroupParam(
     @ApiParam(value = "The name of the CacheGroup that you wish to invalidate", required = true)@PathParam("cacheGroupName") cacheGroupName: String,
-    @ApiParam(value = "The specific parameter value that you wish to invalidate by", required = true)@PathParam("paramValue") paramValue: String) = Action.async { implicit request =>
+    @ApiParam(value = "The specific parameter value that you wish to invalidate by", required = true)@PathParam("paramValue") paramValue: String
+  ) = Action.async { implicit request =>
     val fMaybeCacheGroup = repository.findCacheGroupByName(cacheGroupName)
     fMaybeCacheGroup.flatMap { maybeCacheGroup =>
       maybeCacheGroup.fold {

--- a/app/controllers/PartsController.scala
+++ b/app/controllers/PartsController.scala
@@ -33,7 +33,8 @@ class PartsController(
   requestTimeout: Duration,
   readClientCacheHeaders: Boolean,
   val actorSystem: ActorSystem,
-  implicit val zipkinService: ZipkinServiceLike)
+  implicit val zipkinService: ZipkinServiceLike
+)
     extends Controller
     with LoggingSupport
     with PartListFilterSupport
@@ -48,7 +49,8 @@ class PartsController(
     nickname = "Endpoints invocation",
     notes = "Send an AggregateRequest to invoke backend endpoints. Will respond with an AggregateResponse for you to sort through.",
     response = classOf[AggregateResponse],
-    httpMethod = "POST")
+    httpMethod = "POST"
+  )
   @ApiResponses(Array(new ApiResponse(code = 400, message = "Invalid input")))
   @ApiImplicitParams(Array(new ApiImplicitParam(
     value = "An AggregateRequest consisting of PartRequests that individually invoke a registered backend service once.",
@@ -78,7 +80,8 @@ class PartsController(
     notes = "Returns a list of registered endpoints in the system.",
     response = classOf[HttpPartConfig],
     responseContainer = "List",
-    httpMethod = "GET")
+    httpMethod = "GET"
+  )
   def list(@ApiParam(value = "Optional part ids to filter on. Note, this should be passed as multiple partIdParams=partId, e.g ?partIdParams=wut&partIdParams=wut3 ", allowMultiple = true)@QueryParam("partIdParams") partIdParams: List[String] = Nil) =
     Action.async { implicit req =>
       retrieveParts(partIdParams)
@@ -90,7 +93,8 @@ class PartsController(
     notes = "Returns a list of registered endpoints in the system. Use this if you want to do filtering with so many IDs that you hit the URL limit of our server",
     response = classOf[HttpPartConfig],
     responseContainer = "List",
-    httpMethod = "POST")
+    httpMethod = "POST"
+  )
   @ApiImplicitParams(Array(new ApiImplicitParam(
     value = "An array of ids",
     required = true,
@@ -111,7 +115,8 @@ class PartsController(
       "noCache" -> noCache.toString,
       "timeoutMs" -> aggregateRequest.requestMeta.timeout.fold("default")(_.toMillis.toString),
       "requestUrl" -> aggregateRequest.requestMeta.requestUrl.getOrElse("unknown"),
-      "numParts" -> aggregateRequest.requests.size.toString)
+      "numParts" -> aggregateRequest.requests.size.toString
+    )
     if (underlyingLogger.isDebugEnabled) debugRc(logData: _*) else info(logData: _*)
   }
 

--- a/app/controllers/hystrix/HystrixController.scala
+++ b/app/controllers/hystrix/HystrixController.scala
@@ -12,12 +12,11 @@ import play.api.mvc._
 import scala.concurrent.duration._
 
 class HystrixController(
-  actorSystem: ActorSystem,
-  defaultDelay: FiniteDuration = 1.second,
-  pollerQueueSize: Int = 10000,
-  defaultMaxClients: Int = 10
-)
-    extends Controller {
+    actorSystem: ActorSystem,
+    defaultDelay: FiniteDuration = 1.second,
+    pollerQueueSize: Int = 10000,
+    defaultMaxClients: Int = 10
+) extends Controller {
 
   import actorSystem.dispatcher
 
@@ -53,10 +52,11 @@ class HystrixController(
     val listener = new MetricsAsJsonPollerListener(pollerQueueSize)
     val poller = new HystrixMetricsPoller(listener, delay.toMillis.toInt)
 
-    Enumerator.outputStream(new Streamer(poller, listener, delay)(actorSystem).produce).onDoneEnumerating({
-      onDisconnect()
-      poller.shutdown()
-    })
+    Enumerator.outputStream(new Streamer(poller, listener, delay)(actorSystem).produce)
+      .onDoneEnumerating({
+        onDisconnect()
+        poller.shutdown()
+      })
   }
 
 }

--- a/app/controllers/hystrix/HystrixController.scala
+++ b/app/controllers/hystrix/HystrixController.scala
@@ -15,7 +15,8 @@ class HystrixController(
   actorSystem: ActorSystem,
   defaultDelay: FiniteDuration = 1.second,
   pollerQueueSize: Int = 10000,
-  defaultMaxClients: Int = 10)
+  defaultMaxClients: Int = 10
+)
     extends Controller {
 
   import actorSystem.dispatcher

--- a/app/controllers/hystrix/MetricsAsJsonPollerListener.scala
+++ b/app/controllers/hystrix/MetricsAsJsonPollerListener.scala
@@ -4,8 +4,9 @@ import java.util.concurrent.atomic.AtomicReference
 
 import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsPoller
 
-private class MetricsAsJsonPollerListener(queueSize: Int)
-    extends HystrixMetricsPoller.MetricsAsJsonPollerListener {
+private class MetricsAsJsonPollerListener(
+    queueSize: Int
+) extends HystrixMetricsPoller.MetricsAsJsonPollerListener {
 
   private val metrics = new AtomicReference[Seq[String]](Nil)
 
@@ -20,11 +21,9 @@ private class MetricsAsJsonPollerListener(queueSize: Int)
 
   def handleJsonMetric(json: String): Unit = updateMetrics {
     oldMetrics =>
-      {
-        val newMetrics = oldMetrics :+ json
-        if (newMetrics.size >= queueSize) throw new IllegalStateException("Queue full")
-        newMetrics
-      }
+      val newMetrics = oldMetrics :+ json
+      if (newMetrics.size >= queueSize) throw new IllegalStateException("Queue full")
+      newMetrics
   }
 
   def poll: Seq[String] = flushMetrics match {

--- a/app/controllers/hystrix/Streamer.scala
+++ b/app/controllers/hystrix/Streamer.scala
@@ -9,11 +9,10 @@ import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsPoller
 import scala.concurrent.duration.FiniteDuration
 
 private class Streamer(
-    poller: HystrixMetricsPoller, listener: MetricsAsJsonPollerListener, delay: FiniteDuration
-)(
-    implicit
-    actorSystem: ActorSystem
-) {
+    poller: HystrixMetricsPoller,
+    listener: MetricsAsJsonPollerListener,
+    delay: FiniteDuration
+)(implicit actorSystem: ActorSystem) {
 
   import actorSystem.dispatcher
 
@@ -21,7 +20,9 @@ private class Streamer(
 
   private val scheduleNext = actorSystem.scheduler.scheduleOnce(delay) _
 
-  private def printlnln(out: OutputStream)(s: String): Unit = out.write(s"$s\n\n".getBytes(StandardCharsets.UTF_8))
+  private def printlnln(
+    out: OutputStream
+  )(s: String): Unit = out.write(s"$s\n\n".getBytes(StandardCharsets.UTF_8))
 
   def produce(out: OutputStream): Unit = {
     if (poller.isRunning) {
@@ -36,4 +37,5 @@ private class Streamer(
       }
     }
   }
+
 }

--- a/app/controllers/hystrix/Streamer.scala
+++ b/app/controllers/hystrix/Streamer.scala
@@ -9,8 +9,11 @@ import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsPoller
 import scala.concurrent.duration.FiniteDuration
 
 private class Streamer(
-    poller: HystrixMetricsPoller, listener: MetricsAsJsonPollerListener, delay: FiniteDuration)(
-        implicit actorSystem: ActorSystem) {
+    poller: HystrixMetricsPoller, listener: MetricsAsJsonPollerListener, delay: FiniteDuration
+)(
+    implicit
+    actorSystem: ActorSystem
+) {
 
   import actorSystem.dispatcher
 

--- a/app/controllers/support/AuthSupport.scala
+++ b/app/controllers/support/AuthSupport.scala
@@ -29,7 +29,10 @@ trait AuthSupport
       Action andThen autoAuthenticateRequest
     } { plugin =>
       // Perform authentication check, delegating to plugin if not authenticated
-      Action andThen authenticationCheckFilter(implicit req => plugin.onNotAuthenticated(req, routes.AuthController.callback(req.uri).absoluteURL()))
+      Action andThen
+        authenticationCheckFilter(
+          implicit req => plugin.onNotAuthenticated(req, routes.AuthController.callback(req.uri).absoluteURL())
+        )
     }
   }
 
@@ -44,7 +47,8 @@ trait AuthSupport
       AuthenticatedAction
     } { plugin =>
       // Ask plugin to do authorization check, delegating to plugin if not authenticated
-      AuthenticatedAction andThen authorizationCheckFilter(plugin.isAuthorized, plugin.onUnauthorized)
+      AuthenticatedAction andThen
+        authorizationCheckFilter(plugin.isAuthorized, plugin.onUnauthorized)
     }
   }
 

--- a/app/controllers/support/AuthenticationCheckSupport.scala
+++ b/app/controllers/support/AuthenticationCheckSupport.scala
@@ -18,7 +18,9 @@ trait AuthenticationCheckSupport {
    *
    * @param onUnauthenticated what action to take when a user is not authenticated (e.g. a redirect)
    */
-  protected[support] def authenticationCheckFilter(onUnauthenticated: Request[_] => Future[Result]) = new ActionRefiner[Request, AuthenticatedRequest] {
+  protected[support] def authenticationCheckFilter(
+    onUnauthenticated: Request[_] => Future[Result]
+  ) = new ActionRefiner[Request, AuthenticatedRequest] {
 
     def refine[A](inputReq: Request[A]) = {
       extractPrincipal(inputReq).flatMap { maybePrincipal =>

--- a/app/controllers/support/AuthorizationCheckSupport.scala
+++ b/app/controllers/support/AuthorizationCheckSupport.scala
@@ -19,8 +19,10 @@ trait AuthorizationCheckSupport {
    * @param isAuthorized function to decide whether a request is authorized
    * @param onUnauthorized what action to take when a user is not authenticated (e.g. a redirect)
    */
-  protected[support] def authorizationCheckFilter(isAuthorized: AuthenticatedRequest[_] => Future[Boolean],
-                                                  onUnauthorized: AuthenticatedRequest[_] => Future[Result]) = new ActionFilter[AuthenticatedRequest] {
+  protected[support] def authorizationCheckFilter(
+    isAuthorized: AuthenticatedRequest[_] => Future[Boolean],
+    onUnauthorized: AuthenticatedRequest[_] => Future[Result]
+  ) = new ActionFilter[AuthenticatedRequest] {
 
     def filter[A](inputReq: AuthenticatedRequest[A]) = {
       isAuthorized(inputReq).flatMap { authorized =>

--- a/app/controllers/support/DummyPrincipalSupport.scala
+++ b/app/controllers/support/DummyPrincipalSupport.scala
@@ -15,29 +15,37 @@ trait DummyPrincipalSupport {
    * Create a new guest principal.
    */
   private def createDummyPrincipal(request: Request[_]): Principal =
-    Principal(s"guest${Random.nextInt()}", "guest", s"guest@${request.remoteAddress}", roles = Nil)
+    Principal(
+      s"guest${Random.nextInt()}",
+      "guest",
+      s"guest@${request.remoteAddress}",
+      roles = Nil
+    )
 
   /**
    * An ActionTransformer that creates a guest principal automatically if it doesn't find one in the session.
    * i.e. the user does not need to authenticate - anybody can access the site.
    */
   protected[support] val autoAuthenticateRequest = new ActionFunction[Request, AuthenticatedRequest] {
+    def invokeBlock[A](
+      inputReq: Request[A],
+      block: AuthenticatedRequest[A] => Future[Result]
+    ) = {
+      PrincipalSessionPersistence.extractPrincipalFromPlaySession(inputReq.session)
+        .fold[Future[Result]] {
+          // No valid principal in session, so create a new guest principal and attach it to the request
+          val principal = createDummyPrincipal(inputReq)
+          implicit val authedRequest = AuthenticatedRequest(inputReq, principal)
 
-    def invokeBlock[A](inputReq: Request[A], block: AuthenticatedRequest[A] => Future[Result]) = {
-      PrincipalSessionPersistence.extractPrincipalFromPlaySession(inputReq.session).fold[Future[Result]] {
-        // No valid principal in session, so create a new guest principal and attach it to the request
-        val principal = createDummyPrincipal(inputReq)
-        implicit val authedRequest = AuthenticatedRequest(inputReq, principal)
-
-        // Run the block, then add the newly created principal to the session cookie
-        block(authedRequest).map(result => PrincipalSessionPersistence.savePrincipalToPlaySession(inputReq, result, principal))
-      } { principal =>
-        // Principal found in session - proceed normally
-        val authedRequest = AuthenticatedRequest(inputReq, principal)
-        block(authedRequest)
-      }
+          // Run the block, then add the newly created principal to the session cookie
+          block(authedRequest).map(result =>
+            PrincipalSessionPersistence.savePrincipalToPlaySession(inputReq, result, principal))
+        } { principal =>
+          // Principal found in session - proceed normally
+          val authedRequest = AuthenticatedRequest(inputReq, principal)
+          block(authedRequest)
+        }
     }
-
   }
 
 }

--- a/app/controllers/support/PartListFilterSupport.scala
+++ b/app/controllers/support/PartListFilterSupport.scala
@@ -15,4 +15,6 @@ trait PartListFilterSupport {
 
 }
 
-case class PartListFilter(@(ApiModelProperty @field)(required = true) ids: Seq[String])
+case class PartListFilter(
+  @(ApiModelProperty @field)(required = true) ids: Seq[String]
+)

--- a/app/controllers/system/HealthcheckController.scala
+++ b/app/controllers/system/HealthcheckController.scala
@@ -23,10 +23,12 @@ import scala.util.control.NonFatal
  */
 class HealthcheckController(
   configsRepo: ConfigsRepository,
-    hystrixHealthReporter: HystrixHealthReporter,
-    memcached: RawCache,
-    memcachedCacheKeysToCheck: MemcachedCacheKeysToCheck
-) extends Controller with LogUtil with ReqHeaderToSpanImplicit {
+  hystrixHealthReporter: HystrixHealthReporter,
+  memcached: RawCache,
+  memcachedCacheKeysToCheck: MemcachedCacheKeysToCheck
+) extends Controller
+    with LogUtil
+    with ReqHeaderToSpanImplicit {
 
   import controllers.system.HealthcheckController._
   import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -68,9 +70,21 @@ class HealthcheckController(
         LTSVLogger.warn(e, "Health check failed" -> "DB")
         DbStatus(ok = false, message = e.toString)
     } time {
-      case (status, duration) if duration > 1.second => LTSVLogger.warn("DbStatus" -> status, "Time taken" -> toRelevantUnit(duration))
-      case (status, duration) if duration > 100.milliseconds => LTSVLogger.debug("DbStatus" -> status, "Time taken" -> toRelevantUnit(duration))
-      case (status, duration) => LTSVLogger.trace("DbStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+      case (status, duration) if duration > 1.second =>
+        LTSVLogger.warn(
+          "DbStatus" -> status,
+          "Time taken" -> toRelevantUnit(duration)
+        )
+      case (status, duration) if duration > 100.milliseconds =>
+        LTSVLogger.debug(
+          "DbStatus" -> status,
+          "Time taken" -> toRelevantUnit(duration)
+        )
+      case (status, duration) =>
+        LTSVLogger.trace(
+          "DbStatus" -> status,
+          "Time taken" -> toRelevantUnit(duration)
+        )
     }
   }
 
@@ -84,16 +98,32 @@ class HealthcheckController(
         memcachedGet map { _ => true // Don't care whether we get a cache hit or not
         } recover {
           case NonFatal(e) =>
-            LTSVLogger.warn(e, "Health check failed" -> "Memcached", "key" -> key)
+            LTSVLogger.warn(
+              e,
+              "Health check failed" -> "Memcached",
+              "key" -> key
+            )
             false
         }
       }
     } map {
       bools => MemcachedStatus(bools.forall(identity))
     } time {
-      case (status, duration) if duration > 100.milliseconds => LTSVLogger.warn("MemcachedStatus" -> status, "Time taken" -> toRelevantUnit(duration))
-      case (status, duration) if duration > 10.milliseconds => LTSVLogger.debug("MemcachedStatus" -> status, "Time taken" -> toRelevantUnit(duration))
-      case (status, duration) => LTSVLogger.trace("MemcachedStatus" -> status, "Time taken" -> toRelevantUnit(duration))
+      case (status, duration) if duration > 100.milliseconds =>
+        LTSVLogger.warn(
+          "MemcachedStatus" -> status,
+          "Time taken" -> toRelevantUnit(duration)
+        )
+      case (status, duration) if duration > 10.milliseconds =>
+        LTSVLogger.debug(
+          "MemcachedStatus" -> status,
+          "Time taken" -> toRelevantUnit(duration)
+        )
+      case (status, duration) =>
+        LTSVLogger.trace(
+          "MemcachedStatus" -> status,
+          "Time taken" -> toRelevantUnit(duration)
+        )
     }
   }
 
@@ -107,11 +137,20 @@ class HealthcheckController(
     val hystrixStatus = HystrixStatus(ok, commandKeysWithOpenCircuitBreakers)
     val duration = toRelevantUnit(Duration(System.nanoTime() - startTime, TimeUnit.NANOSECONDS))
     if (duration > 10.milliseconds) {
-      LTSVLogger.warn("HystrixStatus" -> hystrixStatus, "Time taken" -> duration)
+      LTSVLogger.warn(
+        "HystrixStatus" -> hystrixStatus,
+        "Time taken" -> duration
+      )
     } else if (duration > 1.milliseconds) {
-      LTSVLogger.debug("HystrixStatus" -> hystrixStatus, "Time taken" -> duration)
+      LTSVLogger.debug(
+        "HystrixStatus" -> hystrixStatus,
+        "Time taken" -> duration
+      )
     } else {
-      LTSVLogger.trace("HystrixStatus" -> hystrixStatus, "Time taken" -> duration)
+      LTSVLogger.trace(
+        "HystrixStatus" -> hystrixStatus,
+        "Time taken" -> duration
+      )
     }
     hystrixStatus
   }
@@ -123,18 +162,29 @@ object HealthcheckController {
     def ok: Boolean
   }
 
-  case class DbStatus(ok: Boolean, message: String) extends ServiceStatus
+  case class DbStatus(
+    ok: Boolean,
+    message: String
+  ) extends ServiceStatus
 
-  case class HystrixStatus(ok: Boolean, openCircuits: Seq[String]) extends ServiceStatus
+  case class HystrixStatus(
+    ok: Boolean,
+    openCircuits: Seq[String]
+  ) extends ServiceStatus
 
-  case class MemcachedStatus(ok: Boolean) extends ServiceStatus
+  case class MemcachedStatus(
+    ok: Boolean
+  ) extends ServiceStatus
 
   object ServiceHealth {
     val Green = "GREEN"
     val Yellow = "YELLOW"
   }
 
-  case class ServiceHealth(colour: String, statuses: Map[String, ServiceStatus]) {
+  case class ServiceHealth(
+      colour: String,
+      statuses: Map[String, ServiceStatus]
+  ) {
     def healthy: Boolean = colour == ServiceHealth.Green
   }
 
@@ -152,7 +202,11 @@ object HealthcheckController {
 
   private def logIfUnhealthy(health: ServiceHealth): Unit = {
     if (!health.healthy) {
-      LTSVLogger.warn("health" -> "unhealthy", "colour" -> health.colour, "statuses" -> health.statuses.toString)
+      LTSVLogger.warn(
+        "health" -> "unhealthy",
+        "colour" -> health.colour,
+        "statuses" -> health.statuses.toString
+      )
     }
   }
 
@@ -163,5 +217,5 @@ object HealthcheckController {
       ServiceHealth.Yellow
     }
   }
-}
 
+}

--- a/app/controllers/system/HealthcheckController.scala
+++ b/app/controllers/system/HealthcheckController.scala
@@ -21,10 +21,12 @@ import scala.util.control.NonFatal
  * A healthcheck API for use by Nagios.
  * Checks the status of the database and the Hystrix circuit breakers.
  */
-class HealthcheckController(configsRepo: ConfigsRepository,
-                            hystrixHealthReporter: HystrixHealthReporter,
-                            memcached: RawCache,
-                            memcachedCacheKeysToCheck: MemcachedCacheKeysToCheck) extends Controller with LogUtil with ReqHeaderToSpanImplicit {
+class HealthcheckController(
+  configsRepo: ConfigsRepository,
+    hystrixHealthReporter: HystrixHealthReporter,
+    memcached: RawCache,
+    memcachedCacheKeysToCheck: MemcachedCacheKeysToCheck
+) extends Controller with LogUtil with ReqHeaderToSpanImplicit {
 
   import controllers.system.HealthcheckController._
   import play.api.libs.concurrent.Execution.Implicits.defaultContext

--- a/app/controllers/system/MemcachedCacheKeysToCheck.scala
+++ b/app/controllers/system/MemcachedCacheKeysToCheck.scala
@@ -6,12 +6,15 @@ trait MemcachedCacheKeysToCheck extends (() => Seq[String])
  * Generates n random keys. Useful when your memcached setup has several non-redundant instances
  * @param n
  */
-case class RandomMemcachedCacheKeysToCheck(n: Int) extends MemcachedCacheKeysToCheck {
+case class RandomMemcachedCacheKeysToCheck(
+    n: Int
+) extends MemcachedCacheKeysToCheck {
   import org.apache.commons.lang3.RandomStringUtils
 
   def apply() = (1 to n).map { _ => RandomStringUtils.randomAlphanumeric(10) }
 }
 
-object SingleMemcachedCacheKeyToCheck extends MemcachedCacheKeysToCheck {
+object SingleMemcachedCacheKeyToCheck
+    extends MemcachedCacheKeysToCheck {
   def apply() = Seq("ping")
 }

--- a/app/controllers/system/SystemConfigController.scala
+++ b/app/controllers/system/SystemConfigController.scala
@@ -15,7 +15,9 @@ import scala.collection.convert.Wrappers.{ JListWrapper, JSetWrapper }
  * This is the config calculated from merging the defaults with any environment-specific overrides.
  * It has all system properties and environment variables resolved to their appropriate variables.
  */
-class SystemConfigController(config: TSConfig) extends Controller {
+class SystemConfigController(
+    config: TSConfig
+) extends Controller {
 
   def showSystemConfig = Action { request =>
     val maskedConfig = maskPasswords(config)
@@ -39,10 +41,12 @@ class SystemConfigController(config: TSConfig) extends Controller {
 
   private def maskPasswords(config: TSConfig): TSConfig = {
     val passwordPaths = JSetWrapper(config.entrySet).collect {
-      case entry: java.util.Map.Entry[String, _] if entry.getKey.split('.').last == "password" => entry.getKey
+      case entry: java.util.Map.Entry[String, _] if entry.getKey.split('.').last == "password" =>
+        entry.getKey
     }
-    passwordPaths.foldLeft(config) { (cfg, path) => cfg.withValue(path, ConfigValueFactory.fromAnyRef("****", "masked password")) }
+    passwordPaths.foldLeft(config) { (cfg, path) =>
+      cfg.withValue(path, ConfigValueFactory.fromAnyRef("****", "masked password"))
+    }
   }
 
 }
-

--- a/app/presentation/HttpPartConfigView.scala
+++ b/app/presentation/HttpPartConfigView.scala
@@ -52,7 +52,9 @@ case class HttpPartConfigView(config: HttpPartConfig)(implicit messages: Message
 
   def deprecation: Html = config.deprecatedInFavourOf match {
     case Some(s) if s.length() > 0 =>
-      Html(Messages("parts.deprecation.seeOther", s"""<a href="${controllers.routes.AdminController.showPart(s).url}">$s</a>"""))
+      Html(Messages(
+        "parts.deprecation.seeOther", s"""<a href="${controllers.routes.AdminController.showPart(s).url}">$s</a>"""
+      ))
     case _ => Html(Messages("parts.deprecation.none"))
   }
 

--- a/app/presentation/NavbarLinks.scala
+++ b/app/presentation/NavbarLinks.scala
@@ -3,7 +3,9 @@ package presentation
 /**
  * A collection of links to show in the navbar of the admin UI
  */
-case class NavbarLinks(kibana: Option[String],
-                       hystrixDashboard: Option[String],
-                       swaggerUI: Option[String],
-                       wiki: Option[String])
+case class NavbarLinks(
+  kibana: Option[String],
+  hystrixDashboard: Option[String],
+  swaggerUI: Option[String],
+  wiki: Option[String]
+)

--- a/app/presentation/ParamView.scala
+++ b/app/presentation/ParamView.scala
@@ -7,6 +7,7 @@ import org.apache.commons.lang.StringEscapeUtils
  * View adapter for a PartParam.
  */
 case class ParamView(param: PartParam) {
+
   def id: Option[Long] = param.id
 
   def name: String = param.inputNameOverride.getOrElse(param.outputName)
@@ -22,6 +23,7 @@ case class ParamView(param: PartParam) {
   def description = param.description
 
   def inputNameJs = StringEscapeUtils.escapeJavaScript(param.inputName)
+
 }
 
 object ParamView {

--- a/app/views/adminlayout.scala.html
+++ b/app/views/adminlayout.scala.html
@@ -1,4 +1,10 @@
-@(title: String)(meta: Html)(body: Html)(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(title: String)(meta: Html)(body: Html
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
+
 @import com.m3.octoparts.BuildInfo
 @import org.joda.time.DateTime
 @import play.api.Play

--- a/app/views/cachegroup/edit.scala.html
+++ b/app/views/cachegroup/edit.scala.html
@@ -1,4 +1,10 @@
-@(maybeCacheGroup: Option[com.m3.octoparts.model.config.CacheGroup])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  maybeCacheGroup: Option[com.m3.octoparts.model.config.CacheGroup]
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @title = @{
     maybeCacheGroup match {

--- a/app/views/cachegroup/list.scala.html
+++ b/app/views/cachegroup/list.scala.html
@@ -1,4 +1,10 @@
-@(cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup]
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @views.html.adminlayout(Messages("cacheGroups.list")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/app/views/cachegroup/show.scala.html
+++ b/app/views/cachegroup/show.scala.html
@@ -1,4 +1,11 @@
-@(cacheGroup: com.m3.octoparts.model.config.CacheGroup)(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  cacheGroup: com.m3.octoparts.model.config.CacheGroup
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
+
 @views.html.adminlayout(Messages("cacheGroups.detail")) {
 } {
     <h1>@Messages("cacheGroups.detail")</h1>

--- a/app/views/confirmDelete.scala.html
+++ b/app/views/confirmDelete.scala.html
@@ -1,4 +1,12 @@
-@(itemTypeKey: String, itemName: String, cancelUrl: String)(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  itemTypeKey: String,
+  itemName: String,
+  cancelUrl: String
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @views.html.adminlayout(Messages("delete")) { } {
 

--- a/app/views/datatables.scala.html
+++ b/app/views/datatables.scala.html
@@ -1,4 +1,6 @@
-@()(implicit messages: Messages)
+@(
+
+)(implicit messages: Messages)
 
 @datatablesJsAndStyles()
 <script type="text/javascript">

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -1,4 +1,6 @@
-@(navbarLinks: presentation.NavbarLinks)(implicit messages: Messages)
+@(
+  navbarLinks: presentation.NavbarLinks
+)(implicit messages: Messages)
 @import play.api.Play
 
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">

--- a/app/views/param/edit.scala.html
+++ b/app/views/param/edit.scala.html
@@ -1,7 +1,13 @@
-@(form: Form[controllers.AdminForms.ParamData],
-        partId: String,
-        cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup],
-        maybeParam: Option[presentation.ParamView])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  form: Form[controllers.AdminForms.ParamData],
+  partId: String,
+  cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup],
+  maybeParam: Option[presentation.ParamView]
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @title = @{
     maybeParam match {

--- a/app/views/part/edit.scala.html
+++ b/app/views/part/edit.scala.html
@@ -1,7 +1,13 @@
-@(form: Form[controllers.AdminForms.PartData],
+@(
+  form: Form[controllers.AdminForms.PartData],
   threadPoolConfigs: scala.collection.SortedSet[com.m3.octoparts.model.config.ThreadPoolConfig],
   cacheGroups: scala.collection.SortedSet[com.m3.octoparts.model.config.CacheGroup],
-  maybePart: Option[com.m3.octoparts.model.config.HttpPartConfig])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+  maybePart: Option[com.m3.octoparts.model.config.HttpPartConfig]
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @* Override the default field constructor and use our simple one instead *@
 @implicitField = @{ helper.FieldConstructor(simplefield.apply) }

--- a/app/views/part/importForm.scala.html
+++ b/app/views/part/importForm.scala.html
@@ -1,4 +1,9 @@
-@()(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @views.html.adminlayout(Messages("admin.import")) {
 

--- a/app/views/part/list.scala.html
+++ b/app/views/part/list.scala.html
@@ -1,4 +1,10 @@
-@(parts: scala.collection.SortedSet[presentation.HttpPartConfigView])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  parts: scala.collection.SortedSet[presentation.HttpPartConfigView]
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @views.html.adminlayout(Messages("parts.list")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/app/views/part/show.scala.html
+++ b/app/views/part/show.scala.html
@@ -1,4 +1,10 @@
-@(part: presentation.HttpPartConfigView)(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  part: presentation.HttpPartConfigView
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @views.html.adminlayout(Messages("parts.detail")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/app/views/part/test.scala.html
+++ b/app/views/part/test.scala.html
@@ -1,6 +1,20 @@
-@(part: presentation.HttpPartConfigView)(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  part: presentation.HttpPartConfigView
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
-@metaProps = @{Seq("serviceId", "userId", "sessionId", "requestUrl", "userAgent")}
+@metaProps = @{
+  Seq(
+    "serviceId",
+    "userId",
+    "sessionId",
+    "requestUrl",
+    "userAgent"
+  )
+}
 
 @requiredCls(paramView: presentation.ParamView)= {if (required) "required" else "optional"}
 

--- a/app/views/threadpool/edit.scala.html
+++ b/app/views/threadpool/edit.scala.html
@@ -1,18 +1,23 @@
 @import com.m3.octoparts.model.config.ThreadPoolConfig
-@(maybeTpc: Option[com.m3.octoparts.model.config.ThreadPoolConfig])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
-
+@(
+  maybeTpc: Option[com.m3.octoparts.model.config.ThreadPoolConfig]
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @title = @{
-    maybeTpc match {
-        case Some(tpc) => Messages("threadPools.edit", tpc.threadPoolKey)
-        case None => Messages("threadPools.create")
-    }
+  maybeTpc match {
+    case Some(tpc) => Messages("threadPools.edit", tpc.threadPoolKey)
+    case None => Messages("threadPools.create")
+  }
 }
 @postUrl = @{
-    maybeTpc match {
-        case Some(tpc) => controllers.routes.AdminController.updateThreadPool(tpc.id.get)
-        case None => controllers.routes.AdminController.createThreadPool
-    }
+  maybeTpc match {
+    case Some(tpc) => controllers.routes.AdminController.updateThreadPool(tpc.id.get)
+    case None => controllers.routes.AdminController.createThreadPool
+  }
 }
 
 @views.html.adminlayout(title) {

--- a/app/views/threadpool/list.scala.html
+++ b/app/views/threadpool/list.scala.html
@@ -1,4 +1,10 @@
-@(threadPoolConfigs: scala.collection.SortedSet[com.m3.octoparts.model.config.ThreadPoolConfig])(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  threadPoolConfigs: scala.collection.SortedSet[com.m3.octoparts.model.config.ThreadPoolConfig]
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @views.html.adminlayout(Messages("threadPools.list")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/app/views/threadpool/show.scala.html
+++ b/app/views/threadpool/show.scala.html
@@ -1,4 +1,10 @@
-@(tpc: com.m3.octoparts.model.config.ThreadPoolConfig)(implicit flash: Flash, navbarLinks: presentation.NavbarLinks, messages: Messages)
+@(
+  tpc: com.m3.octoparts.model.config.ThreadPoolConfig
+)(implicit
+  flash: Flash,
+  navbarLinks: presentation.NavbarLinks,
+  messages: Messages
+)
 
 @views.html.adminlayout(Messages("threadPools.detail")) {
     <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" />

--- a/auth-handler-api/src/main/scala/com/m3/octoparts/auth/AuthenticatedRequest.scala
+++ b/auth-handler-api/src/main/scala/com/m3/octoparts/auth/AuthenticatedRequest.scala
@@ -3,4 +3,7 @@ package com.m3.octoparts.auth
 import play.api.mvc.{ Request, WrappedRequest }
 
 /** An authenticated request, i.e. one with a valid principal */
-case class AuthenticatedRequest[A](request: Request[A], principal: Principal) extends WrappedRequest[A](request)
+case class AuthenticatedRequest[A](
+  request: Request[A],
+  principal: Principal
+) extends WrappedRequest[A](request)

--- a/auth-handler-api/src/main/scala/com/m3/octoparts/auth/OctopartsAuthHandler.scala
+++ b/auth-handler-api/src/main/scala/com/m3/octoparts/auth/OctopartsAuthHandler.scala
@@ -42,7 +42,10 @@ trait OctopartsAuthHandler {
    *                    It will include the current (relative) URL as a query parameter,
    *                    e.g. "http://octoparts:9000/auth/callback?origUrl=%2Fadmin"
    */
-  def onNotAuthenticated(request: Request[_], callbackUrl: String)(implicit exec: ExecutionContext): Future[Result]
+  def onNotAuthenticated(
+    request: Request[_],
+    callbackUrl: String
+  )(implicit exec: ExecutionContext): Future[Result]
 
   /**
    * Whether the given principal is authorized to use the Octoparts admin UI.
@@ -50,37 +53,52 @@ trait OctopartsAuthHandler {
    * @param authenticatedRequest an authenticated request with a [[com.m3.octoparts.auth.Principal]]
    * @return your decision
    */
-  def isAuthorized(authenticatedRequest: AuthenticatedRequest[_])(implicit exec: ExecutionContext): Future[Boolean]
+  def isAuthorized(
+    authenticatedRequest: AuthenticatedRequest[_]
+  )(implicit exec: ExecutionContext): Future[Boolean]
 
   /**
    * What action to take when a request is authenticated but the principal is not authorized.
    *
    * @param authenticatedRequest an authenticated request with a [[com.m3.octoparts.auth.Principal]]
    */
-  def onUnauthorized(authenticatedRequest: AuthenticatedRequest[_])(implicit exec: ExecutionContext): Future[Result]
+  def onUnauthorized(
+    authenticatedRequest: AuthenticatedRequest[_]
+  )(implicit exec: ExecutionContext): Future[Result]
 
   /**
    * Use a post-authentication callback from an external authentication provider to construct a [[com.m3.octoparts.auth.Principal]]
    *
    * @return a Principal constructed from the HTTP request
    */
-  def onAuthenticationCallback(request: Request[_])(implicit exec: ExecutionContext): Future[Principal]
+  def onAuthenticationCallback(
+    request: Request[_]
+  )(implicit exec: ExecutionContext): Future[Principal]
 
   /**
    * When the user logs out, they are redirected to the top page.
    * This callback is your chance to clean up their session, e.g. delete cookies.
    * The default implementation removes the Principal from the Play session cookie.
    */
-  def onLogout(request: Request[_], result: Result): Future[Result] = {
-    Future.successful(PrincipalSessionPersistence.deletePrincipalFromPlaySession(request, result))
+  def onLogout(
+    request: Request[_],
+    result: Result
+  ): Future[Result] = {
+    Future.successful(
+      PrincipalSessionPersistence.deletePrincipalFromPlaySession(request, result)
+    )
   }
 
   /**
    * Try to extract a Principal from the session.
    * The default implementation extracts the JSON-serialized Principal from the Play session cookie.
    */
-  def loadPrincipal(request: Request[_])(implicit exec: ExecutionContext): Future[Option[Principal]] = {
-    Future.successful(PrincipalSessionPersistence.extractPrincipalFromPlaySession(request.session))
+  def loadPrincipal(
+    request: Request[_]
+  )(implicit exec: ExecutionContext): Future[Option[Principal]] = {
+    Future.successful(
+      PrincipalSessionPersistence.extractPrincipalFromPlaySession(request.session)
+    )
   }
 
   /**
@@ -88,9 +106,18 @@ trait OctopartsAuthHandler {
    * This callback is your change to save the principal to a session.
    * The default implementation saves it as JSON to the Play session cookie.
    */
-  def savePrincipal(request: Request[_], result: Result, principal: Principal): Future[Result] = {
-    Future.successful(PrincipalSessionPersistence.savePrincipalToPlaySession(request, result, principal))
+  def savePrincipal(
+    request: Request[_],
+    result: Result,
+    principal: Principal
+  ): Future[Result] = {
+    Future.successful(
+      PrincipalSessionPersistence.savePrincipalToPlaySession(
+        request,
+        result,
+        principal
+      )
+    )
   }
 
 }
-

--- a/auth-handler-api/src/main/scala/com/m3/octoparts/auth/Principal.scala
+++ b/auth-handler-api/src/main/scala/com/m3/octoparts/auth/Principal.scala
@@ -3,7 +3,12 @@ package com.m3.octoparts.auth
 import play.api.libs.json.Json
 
 /** A principal, i.e. an authenticated user */
-case class Principal(id: String, nickname: String, email: String, roles: Seq[String])
+case class Principal(
+  id: String,
+  nickname: String,
+  email: String,
+  roles: Seq[String]
+)
 
 object Principal {
 

--- a/auth-handler-api/src/main/scala/com/m3/octoparts/auth/PrincipalSessionPersistence.scala
+++ b/auth-handler-api/src/main/scala/com/m3/octoparts/auth/PrincipalSessionPersistence.scala
@@ -20,33 +20,45 @@ object PrincipalSessionPersistence {
    * Look up the Principal object in the Play session and deserialize it from Json
    */
   def extractPrincipalFromPlaySession(session: Session): Option[Principal] = {
-    session.get(SessionKey).flatMap { sessionValue =>
-      Try(Json.parse(sessionValue)) match {
-        case Failure(e) =>
-          LTSVLogger.warn("Rejecting invalid principal found in session (not valid json)" -> sessionValue)
-          None
-        case Success(json) =>
-          json.validate[Principal] match {
-            case JsError(_) =>
-              LTSVLogger.warn("Rejecting invalid principal found in session (unexpected json)" -> sessionValue)
-              None
-            case JsSuccess(principal, _) =>
-              // Everything's OK
-              Some(principal)
-          }
+    session.get(SessionKey)
+      .flatMap { sessionValue =>
+        Try(Json.parse(sessionValue)) match {
+          case Failure(e) =>
+            LTSVLogger.warn(
+              "Rejecting invalid principal found in session (not valid json)" -> sessionValue
+            )
+            None
+          case Success(json) =>
+            json.validate[Principal] match {
+              case JsError(_) =>
+                LTSVLogger.warn(
+                  "Rejecting invalid principal found in session (unexpected json)" -> sessionValue
+                )
+                None
+              case JsSuccess(principal, _) =>
+                // Everything's OK
+                Some(principal)
+            }
+        }
       }
-    }
   }
 
   /**
    * Persist the Principal in the Play session cookie
    */
-  def savePrincipalToPlaySession(request: Request[_], result: Result, principal: Principal): Result =
+  def savePrincipalToPlaySession(
+    request: Request[_],
+    result: Result,
+    principal: Principal
+  ): Result =
     result.addingToSession(SessionKey -> Json.toJson(principal).toString)(request)
 
   /**
    * Delete the Principal object from the Play session cookie
    */
-  def deletePrincipalFromPlaySession(request: Request[_], result: Result): Result = result.removingFromSession(SessionKey)(request)
+  def deletePrincipalFromPlaySession(
+    request: Request[_],
+    result: Result
+  ): Result = result.removingFromSession(SessionKey)(request)
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ def nonPlayProject(projectName: String)(baseFile: String = projectName): Project
     id = projectName,
     base = file(baseFile),
     settings = nonPlayAppSettings
-  ).settings(name := projectName)
+  ).settings(name := projectName).settings(Scalariform.settings)
 }
 
 // -------------------------------------------------------

--- a/java-client/src/main/scala/com/m3/octoparts/client/AggregateResponseExtractor.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/AggregateResponseExtractor.scala
@@ -19,7 +19,9 @@ private[client] object AggregateResponseExtractor {
   }
 }
 
-private[client] class AggregateResponseExtractor(aggregateRequest: AggregateRequest) extends AsyncCompletionHandler[ResponseWrapper] {
+private[client] class AggregateResponseExtractor(
+    aggregateRequest: AggregateRequest
+) extends AsyncCompletionHandler[ResponseWrapper] {
 
   import com.m3.octoparts.client.AggregateResponseExtractor._
 

--- a/java-client/src/main/scala/com/m3/octoparts/client/DefaultPartResponseWrapper.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/DefaultPartResponseWrapper.scala
@@ -9,7 +9,9 @@ private[client] object DefaultPartResponseWrapper {
   private val Log = LoggerFactory.getLogger(classOf[DefaultPartResponseWrapper])
 }
 
-private[client] case class DefaultPartResponseWrapper(partResponse: PartResponse) extends PartResponseWrapper {
+private[client] case class DefaultPartResponseWrapper(
+    partResponse: PartResponse
+) extends PartResponseWrapper {
 
   import com.m3.octoparts.client.DefaultPartResponseWrapper._
 
@@ -20,7 +22,9 @@ private[client] case class DefaultPartResponseWrapper(partResponse: PartResponse
   /**
    * @param defaultContents what to return if there were no contents
    */
-  def getContents(defaultContents: String) = partResponse.contents.filter(_.length > 0 && partResponse.errors.isEmpty).getOrElse(defaultContents)
+  def getContents(defaultContents: String) =
+    partResponse.contents.filter(_.length > 0 &&
+      partResponse.errors.isEmpty).getOrElse(defaultContents)
 
   def getCookies = WrapAsJava.seqAsJavaList(partResponse.cookies)
 

--- a/java-client/src/main/scala/com/m3/octoparts/client/DefaultResponseWrapper.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/DefaultResponseWrapper.scala
@@ -4,7 +4,9 @@ import com.m3.octoparts.model.{ AggregateResponse, PartResponse, ResponseMeta }
 
 import scala.collection.convert.WrapAsJava
 
-private[client] case class DefaultResponseWrapper(aggregateResponse: AggregateResponse) extends ResponseWrapper {
+private[client] case class DefaultResponseWrapper(
+    aggregateResponse: AggregateResponse
+) extends ResponseWrapper {
 
   private def wrap(partResponse: Option[PartResponse]): PartResponseWrapper =
     partResponse.fold[PartResponseWrapper](EmptyPartResponseWrapper)(DefaultPartResponseWrapper.apply)

--- a/java-client/src/main/scala/com/m3/octoparts/client/DurationModule.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/DurationModule.scala
@@ -15,9 +15,11 @@ private[client] trait DurationModule extends JacksonModule {
 
   private object DurationSerializerResolver extends Serializers.Base {
 
-    override def findSerializer(config: SerializationConfig,
-                                javaType: JavaType,
-                                beanDescription: BeanDescription): JsonSerializer[_] = {
+    override def findSerializer(
+      config: SerializationConfig,
+      javaType: JavaType,
+      beanDescription: BeanDescription
+    ): JsonSerializer[_] = {
 
       if (classOf[Duration].isAssignableFrom(javaType.getRawClass)) {
         DurationSerializer
@@ -35,9 +37,11 @@ private[client] trait DurationModule extends JacksonModule {
 
   private object DurationDeserializerResolver extends Deserializers.Base {
 
-    override def findBeanDeserializer(javaType: JavaType,
-                                      config: DeserializationConfig,
-                                      beanDesc: BeanDescription) = {
+    override def findBeanDeserializer(
+      javaType: JavaType,
+      config: DeserializationConfig,
+      beanDesc: BeanDescription
+    ) = {
 
       if (classOf[Duration].isAssignableFrom(javaType.getRawClass)) {
         new DurationDeserializer(javaType)

--- a/java-client/src/main/scala/com/m3/octoparts/client/ExtendedScalaModule.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/ExtendedScalaModule.scala
@@ -2,5 +2,6 @@ package com.m3.octoparts.client
 
 import com.fasterxml.jackson.module.scala._
 
-object ExtendedScalaModule extends DefaultScalaModule with DurationModule
-
+object ExtendedScalaModule
+  extends DefaultScalaModule
+  with DurationModule

--- a/java-client/src/main/scala/com/m3/octoparts/client/OKResponseExtractor.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/OKResponseExtractor.scala
@@ -7,7 +7,9 @@ private[client] object OKResponseExtractor {
   private final val Log = LoggerFactory.getLogger(classOf[OKResponseExtractor])
 }
 
-private[client] class OKResponseExtractor(uri: String) extends AsyncCompletionHandler[java.lang.Boolean] {
+private[client] class OKResponseExtractor(
+    uri: String
+) extends AsyncCompletionHandler[java.lang.Boolean] {
 
   import com.m3.octoparts.client.OKResponseExtractor._
 

--- a/java-client/src/main/scala/com/m3/octoparts/client/OctopartsApiBuilder.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/OctopartsApiBuilder.scala
@@ -38,8 +38,7 @@ class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: Stri
   private val asyncHttpClient = new AsyncHttpClient(asyncHttpClientConfig)
 
   def this(@Nonnull apiRootUrl: String, @Nullable serviceId: String) = this(apiRootUrl, serviceId,
-    new AsyncHttpClientConfig.Builder().setCompressionEnforced(true).setFollowRedirect(false).setAllowPoolingConnections(true).setMaxRequestRetry(0).build
-  )
+    new AsyncHttpClientConfig.Builder().setCompressionEnforced(true).setFollowRedirect(false).setAllowPoolingConnections(true).setMaxRequestRetry(0).build)
 
   def close() = asyncHttpClient.close()
 

--- a/java-client/src/main/scala/com/m3/octoparts/client/OctopartsApiBuilder.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/OctopartsApiBuilder.scala
@@ -29,7 +29,11 @@ private[client] object OctopartsApiBuilder {
   Mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 }
 
-class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: String, @Nonnull asyncHttpClientConfig: AsyncHttpClientConfig) extends Closeable {
+class OctopartsApiBuilder(
+    @Nonnull apiRootUrl: String,
+    @Nullable serviceId: String,
+    @Nonnull asyncHttpClientConfig: AsyncHttpClientConfig
+) extends Closeable {
 
   import com.m3.octoparts.client.OctopartsApiBuilder._
 
@@ -37,8 +41,21 @@ class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: Stri
   private val cacheApiEndpointUrl = s"$octopartsApiEndpointUrl/cache"
   private val asyncHttpClient = new AsyncHttpClient(asyncHttpClientConfig)
 
-  def this(@Nonnull apiRootUrl: String, @Nullable serviceId: String) = this(apiRootUrl, serviceId,
-    new AsyncHttpClientConfig.Builder().setCompressionEnforced(true).setFollowRedirect(false).setAllowPoolingConnections(true).setMaxRequestRetry(0).build)
+  def this(
+    @Nonnull apiRootUrl: String,
+    @Nullable serviceId: String
+  ) = this(
+    apiRootUrl,
+    serviceId,
+    {
+      new AsyncHttpClientConfig.Builder()
+        .setCompressionEnforced(true)
+        .setFollowRedirect(false)
+        .setAllowPoolingConnections(true)
+        .setMaxRequestRetry(0)
+        .build()
+    }
+  )
 
   def close() = asyncHttpClient.close()
 
@@ -50,20 +67,39 @@ class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: Stri
    * @param requestUrl optional request URL
    * @param timeoutMs This value is enforced in the octoparts server.
    */
-  def newRequest(@Nullable userId: String, @Nullable sessionId: String, @Nullable userAgent: String, @Nullable requestUrl: String, @Nullable timeoutMs: java.lang.Long): RequestBuilder = {
-    val timeoutOpt = if (timeoutMs == null) None else Some(timeoutMs.longValue().millis)
-    val requestMeta = RequestMeta(UUID.randomUUID.toString, Option(serviceId), Option(userId), Option(sessionId), Option(requestUrl), Option(userAgent), timeoutOpt)
+  def newRequest(
+    @Nullable userId: String,
+    @Nullable sessionId: String,
+    @Nullable userAgent: String,
+    @Nullable requestUrl: String,
+    @Nullable timeoutMs: java.lang.Long
+  ): RequestBuilder = {
+    val timeoutOpt = {
+      if (timeoutMs == null) None
+      else Some(timeoutMs.longValue().millis)
+    }
+    val requestMeta = RequestMeta(
+      UUID.randomUUID.toString,
+      Option(serviceId),
+      Option(userId),
+      Option(sessionId),
+      Option(requestUrl),
+      Option(userAgent), timeoutOpt
+    )
     new RequestBuilder(requestMeta)
   }
 
-  @varargs private[client] def toHttp(aggregateRequest: AggregateRequest, additionalHeaders: (String, String)*) = {
+  @varargs private[client] def toHttp(
+    aggregateRequest: AggregateRequest,
+    additionalHeaders: (String, String)*
+  ) = {
     Log.debug(s"${aggregateRequest.requests.size} octoparts")
     val jsonContent = Mapper.writeValueAsBytes(aggregateRequest)
-    var requestBuilder = asyncHttpClient.
-      preparePost(octopartsApiEndpointUrl).
-      addHeader("Content-Type", "application/json;charset=UTF-8").
-      addHeader("Content-Length", jsonContent.length.toString).
-      setBody(jsonContent)
+    var requestBuilder = asyncHttpClient
+      .preparePost(octopartsApiEndpointUrl)
+      .addHeader("Content-Type", "application/json;charset=UTF-8")
+      .addHeader("Content-Length", jsonContent.length.toString)
+      .setBody(jsonContent)
     additionalHeaders.foreach {
       case (k, v) => requestBuilder = requestBuilder.addHeader(k, v)
     }
@@ -73,8 +109,14 @@ class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: Stri
   /**
    * Sends a request to the Octoparts server.
    */
-  @varargs def submit(@Nonnull aggregateRequest: AggregateRequest, additionalHeaders: (String, String)*): ListenableFuture[ResponseWrapper] = {
-    asyncHttpClient.executeRequest(toHttp(aggregateRequest, additionalHeaders: _*), new AggregateResponseExtractor(aggregateRequest))
+  @varargs def submit(
+    @Nonnull aggregateRequest: AggregateRequest,
+    additionalHeaders: (String, String)*
+  ): ListenableFuture[ResponseWrapper] = {
+    asyncHttpClient.executeRequest(
+      toHttp(aggregateRequest, additionalHeaders: _*),
+      new AggregateResponseExtractor(aggregateRequest)
+    )
   }
 
   /**
@@ -90,8 +132,17 @@ class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: Stri
    * Invalidates a region of the cache for a part.
    * If the part or the region does not exist, returns true anyways.
    */
-  @Nonnull def invalidateCacheFor(@Nonnull partId: String, @Nonnull parameterName: String, @Nullable parameterValue: String): ListenableFuture[java.lang.Boolean] = {
-    val uri = formatWithUriEscape("/invalidate/part/%s/%s/%s", partId, parameterName, parameterValue)
+  @Nonnull def invalidateCacheFor(
+    @Nonnull partId: String,
+    @Nonnull parameterName: String,
+    @Nullable parameterValue: String
+  ): ListenableFuture[java.lang.Boolean] = {
+    val uri = formatWithUriEscape(
+      "/invalidate/part/%s/%s/%s",
+      partId,
+      parameterName,
+      parameterValue
+    )
     sendCachePost(uri)
   }
 
@@ -108,23 +159,34 @@ class OctopartsApiBuilder(@Nonnull apiRootUrl: String, @Nullable serviceId: Stri
    * Invalidates a region for a group of caches
    * If the group does not exist, returns false.
    */
-  @Nonnull def invalidateCacheGroupFor(@Nonnull groupName: String, @Nullable parameterValue: String): ListenableFuture[java.lang.Boolean] = {
-    val uri = formatWithUriEscape("/invalidate/cacheGroup/%s/params/%s", groupName, parameterValue)
+  @Nonnull def invalidateCacheGroupFor(
+    @Nonnull groupName: String,
+    @Nullable parameterValue: String
+  ): ListenableFuture[java.lang.Boolean] = {
+    val uri = formatWithUriEscape(
+      "/invalidate/cacheGroup/%s/params/%s",
+      groupName,
+      parameterValue
+    )
     sendCachePost(uri)
   }
 
   /**
-   * @param partIds when specified, filters the endpoint list. Note: not specifying a filter will prevent Octoparts from using the part config cache.
+   * @param partIds when specified, filters the endpoint list.
+   * Note: not specifying a filter will prevent Octoparts from using the part config cache.
    */
-  @varargs @Nonnull def listEndpoints(@Nonnull partIds: String*): ListenableFuture[java.util.List[HttpPartConfig]] = {
+  @varargs @Nonnull def listEndpoints(
+    @Nonnull partIds: String*
+  ): ListenableFuture[java.util.List[HttpPartConfig]] = {
     import scala.collection.convert.Wrappers._
     val queryParams: java.util.Map[String, java.util.List[String]] = {
-      if (partIds.isEmpty) java.util.Collections.emptyMap() else MutableMapWrapper(scala.collection.mutable.Map("partIdParams" -> SeqWrapper(partIds)))
+      if (partIds.isEmpty) java.util.Collections.emptyMap()
+      else MutableMapWrapper(scala.collection.mutable.Map("partIdParams" -> SeqWrapper(partIds)))
     }
-    val request = asyncHttpClient.
-      prepareGet(s"$octopartsApiEndpointUrl/list").
-      setQueryParams(queryParams).
-      build
+    val request = asyncHttpClient
+      .prepareGet(s"$octopartsApiEndpointUrl/list")
+      .setQueryParams(queryParams)
+      .build()
     asyncHttpClient.executeRequest(request, EndpointListExtractor)
   }
 

--- a/java-client/src/main/scala/com/m3/octoparts/client/RequestBuilder.scala
+++ b/java-client/src/main/scala/com/m3/octoparts/client/RequestBuilder.scala
@@ -12,18 +12,35 @@ private[client] class RequestBuilder(requestMeta: RequestMeta) {
 
   def build = partRequests.synchronized(AggregateRequest(requestMeta, partRequests.result()))
 
-  @Nonnull def newPart(@Nonnull partId: String, @Nullable id: String) = new PartBuilder(partId, Option(id))
+  @Nonnull def newPart(
+    @Nonnull partId: String,
+    @Nullable id: String
+  ) = new PartBuilder(partId, Option(id))
 
-  class PartBuilder private[client] (partId: String, id: Option[String]) {
+  class PartBuilder private[client] (
+      partId: String,
+      id: Option[String]
+  ) {
+
     private[this] val params = Seq.newBuilder[PartRequestParam]
 
-    @Nonnull def addParam(@Nonnull key: String, @Nonnull value: String): PartBuilder = {
+    @Nonnull def addParam(
+      @Nonnull key: String,
+      @Nonnull value: String
+    ): PartBuilder = {
       params.synchronized(params += PartRequestParam(key, value))
       this
     }
 
-    @Nonnull def addParams(@Nonnull someParams: util.Map[String, String]): PartBuilder = {
-      val manyParams = for ((k, v) <- WrapAsScala.mapAsScalaMap(someParams) if k != null && v != null) yield PartRequestParam(k, v)
+    @Nonnull def addParams(
+      @Nonnull someParams: util.Map[String, String]
+    ): PartBuilder = {
+      val manyParams = {
+        for {
+          (k, v) <- WrapAsScala.mapAsScalaMap(someParams)
+          if k != null && v != null
+        } yield PartRequestParam(k, v)
+      }
       params.synchronized(params ++= manyParams)
       this
     }

--- a/models/src/main/scala/com/m3/octoparts/model/AggregateRequest.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/AggregateRequest.scala
@@ -13,8 +13,10 @@ import scala.concurrent.duration.FiniteDuration
  * @param requestMeta RequestMeta
  * @param requests List[PartRequest]
  */
-case class AggregateRequest(@(ApiModelProperty @field)(required = true)@BeanProperty requestMeta: RequestMeta,
-                            @BeanProperty requests: Seq[PartRequest] = Nil)
+case class AggregateRequest(
+  @(ApiModelProperty @field)(required = true)@BeanProperty requestMeta: RequestMeta,
+  @BeanProperty requests: Seq[PartRequest] = Nil
+)
 
 case class RequestMeta(
   @(ApiModelProperty @field)(required = true)@BeanProperty id: String,
@@ -23,7 +25,8 @@ case class RequestMeta(
   @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty sessionId: Option[String] = None,
   @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty requestUrl: Option[String] = None,
   @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty userAgent: Option[String] = None,
-  @(ApiModelProperty @field)(required = false, dataType = "integer", value = "in ms")@BeanProperty timeout: Option[FiniteDuration] = None)
+  @(ApiModelProperty @field)(required = false, dataType = "integer", value = "in ms")@BeanProperty timeout: Option[FiniteDuration] = None
+)
 
 /**
  * A request for a given part. One of more of these can be combined into a single AggregateRequest.
@@ -37,11 +40,15 @@ case class RequestMeta(
  *           Useful when an [[AggregateRequest]] contains several [[PartRequest]]s with the same partId
  * @param params list of parameters. Several parameters can have the same key; within those, order is kept as much a can be.
  */
-case class PartRequest(@(ApiModelProperty @field)(required = true)@BeanProperty partId: String,
-                       @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty id: Option[String] = None,
-                       // TODO use a Map[String, Seq[String]] here when Swagger finally supports maps.
-                       @BeanProperty params: Seq[PartRequestParam] = Nil)
+case class PartRequest(
+  @(ApiModelProperty @field)(required = true)@BeanProperty partId: String,
+  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty id: Option[String] = None,
+  // TODO use a Map[String, Seq[String]] here when Swagger finally supports maps.
+  @BeanProperty params: Seq[PartRequestParam] = Nil
+)
 
-case class PartRequestParam(@(ApiModelProperty @field)(required = true)@BeanProperty key: String,
-                            @(ApiModelProperty @field)(required = true)@BeanProperty value: String)
+case class PartRequestParam(
+  @(ApiModelProperty @field)(required = true)@BeanProperty key: String,
+  @(ApiModelProperty @field)(required = true)@BeanProperty value: String
+)
 

--- a/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration.FiniteDuration
  * @param responses PartResponse
  */
 case class AggregateResponse(
-  @(ApiModelProperty @field)(required = true)@BeanProperty responseMeta: ResponseMeta,
+    @(ApiModelProperty @field)(required = true)@BeanProperty responseMeta: ResponseMeta,
     @BeanProperty responses: Seq[PartResponse] = Nil
 ) {
 
@@ -104,7 +104,7 @@ object CacheControl {
  * @param lastModified a date. we do not parse it and use it as-is
  */
 case class CacheControl(
-  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty noStore: Boolean = false,
+    @(ApiModelProperty @field)(required = true)@BooleanBeanProperty noStore: Boolean = false,
     @(ApiModelProperty @field)(required = true)@BooleanBeanProperty noCache: Boolean = false,
     @(ApiModelProperty @field)(required = false, dataType = "long")@BeanProperty expiresAt: Option[Long] = None,
     @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty etag: Option[String] = None,

--- a/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/AggregateResponse.scala
@@ -14,8 +14,10 @@ import scala.concurrent.duration.FiniteDuration
  * @param responseMeta ResponseMeta
  * @param responses PartResponse
  */
-case class AggregateResponse(@(ApiModelProperty @field)(required = true)@BeanProperty responseMeta: ResponseMeta,
-                             @BeanProperty responses: Seq[PartResponse] = Nil) {
+case class AggregateResponse(
+  @(ApiModelProperty @field)(required = true)@BeanProperty responseMeta: ResponseMeta,
+    @BeanProperty responses: Seq[PartResponse] = Nil
+) {
 
   @(ApiModelProperty @field)(hidden = true)
   private lazy val partsLookup = responses.map(r => r.id -> r).toMap
@@ -38,8 +40,10 @@ case class AggregateResponse(@(ApiModelProperty @field)(required = true)@BeanPro
 
 }
 
-case class ResponseMeta(@(ApiModelProperty @field)(required = true)@BeanProperty id: String,
-                        @(ApiModelProperty @field)(required = true, dataType = "integer", value = "in ms")@BeanProperty processTime: FiniteDuration)
+case class ResponseMeta(
+  @(ApiModelProperty @field)(required = true)@BeanProperty id: String,
+  @(ApiModelProperty @field)(required = true, dataType = "integer", value = "in ms")@BeanProperty processTime: FiniteDuration
+)
 
 /**
  * @param partId same as corresponding partRequest
@@ -56,32 +60,36 @@ case class ResponseMeta(@(ApiModelProperty @field)(required = true)@BeanProperty
  * @param retrievedFromLocalContents
  *
  */
-case class PartResponse(@(ApiModelProperty @field)(required = true)@BeanProperty partId: String,
-                        @(ApiModelProperty @field)(required = true)@BeanProperty id: String,
-                        @BeanProperty cookies: Seq[Cookie] = Nil,
-                        @(ApiModelProperty @field)(required = false, dataType = "integer")@BeanProperty statusCode: Option[Int] = None,
-                        @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty mimeType: Option[String] = None,
-                        @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty charset: Option[String] = None,
-                        @BeanProperty cacheControl: CacheControl = CacheControl.NotSet,
-                        @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty contents: Option[String] = None,
-                        @BeanProperty warnings: Seq[String] = Nil,
-                        @BeanProperty errors: Seq[String] = Nil,
-                        @(ApiModelProperty @field)(required = true)@BooleanBeanProperty retrievedFromCache: Boolean = false,
-                        @(ApiModelProperty @field)(required = true)@BooleanBeanProperty retrievedFromLocalContents: Boolean = false)
+case class PartResponse(
+  @(ApiModelProperty @field)(required = true)@BeanProperty partId: String,
+  @(ApiModelProperty @field)(required = true)@BeanProperty id: String,
+  @BeanProperty cookies: Seq[Cookie] = Nil,
+  @(ApiModelProperty @field)(required = false, dataType = "integer")@BeanProperty statusCode: Option[Int] = None,
+  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty mimeType: Option[String] = None,
+  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty charset: Option[String] = None,
+  @BeanProperty cacheControl: CacheControl = CacheControl.NotSet,
+  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty contents: Option[String] = None,
+  @BeanProperty warnings: Seq[String] = Nil,
+  @BeanProperty errors: Seq[String] = Nil,
+  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty retrievedFromCache: Boolean = false,
+  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty retrievedFromLocalContents: Boolean = false
+)
 
 /**
  * Immutable wrapper for cookies
  *
  * Ideally we should handle no more than these fields
  */
-case class Cookie(@(ApiModelProperty @field)(required = true)@BeanProperty name: String,
-                  @(ApiModelProperty @field)(required = true)@BeanProperty value: String,
-                  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty httpOnly: Boolean,
-                  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty secure: Boolean,
-                  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty discard: Boolean,
-                  @(ApiModelProperty @field)(required = true)@BeanProperty maxAge: Long,
-                  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty path: Option[String],
-                  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty domain: Option[String])
+case class Cookie(
+  @(ApiModelProperty @field)(required = true)@BeanProperty name: String,
+  @(ApiModelProperty @field)(required = true)@BeanProperty value: String,
+  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty httpOnly: Boolean,
+  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty secure: Boolean,
+  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty discard: Boolean,
+  @(ApiModelProperty @field)(required = true)@BeanProperty maxAge: Long,
+  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty path: Option[String],
+  @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty domain: Option[String]
+)
 
 object CacheControl {
   val NotSet = CacheControl()
@@ -95,11 +103,13 @@ object CacheControl {
  * @param etag backend-defined String to be used for validation
  * @param lastModified a date. we do not parse it and use it as-is
  */
-case class CacheControl(@(ApiModelProperty @field)(required = true)@BooleanBeanProperty noStore: Boolean = false,
-                        @(ApiModelProperty @field)(required = true)@BooleanBeanProperty noCache: Boolean = false,
-                        @(ApiModelProperty @field)(required = false, dataType = "long")@BeanProperty expiresAt: Option[Long] = None,
-                        @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty etag: Option[String] = None,
-                        @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty lastModified: Option[String] = None) {
+case class CacheControl(
+  @(ApiModelProperty @field)(required = true)@BooleanBeanProperty noStore: Boolean = false,
+    @(ApiModelProperty @field)(required = true)@BooleanBeanProperty noCache: Boolean = false,
+    @(ApiModelProperty @field)(required = false, dataType = "long")@BeanProperty expiresAt: Option[Long] = None,
+    @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty etag: Option[String] = None,
+    @(ApiModelProperty @field)(required = false, dataType = "string")@BeanProperty lastModified: Option[String] = None
+) {
 
   def canRevalidate = etag.isDefined || lastModified.isDefined
 }

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/AlertMailSettings.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/AlertMailSettings.scala
@@ -10,7 +10,8 @@ case class AlertMailSettings(
   @(ApiModelProperty @field)(dataType = "integer", required = false, allowableValues = "range[0, Infinity]") alertAbsoluteThreshold: Option[Int] = None,
   @(ApiModelProperty @field)(dataType = "float", required = false, allowableValues = "range[0, 100]") alertPercentThreshold: Option[Double] = None,
   @(ApiModelProperty @field)(dataType = "integer", required = true, allowableValues = "range[0, Infinity]", value = "in ms") alertInterval: FiniteDuration,
-  @(ApiModelProperty @field)(dataType = "string", required = false) alertMailRecipients: Option[String] = None)
+  @(ApiModelProperty @field)(dataType = "string", required = false) alertMailRecipients: Option[String] = None
+)
 
 object AlertMailSettings {
   val Off = AlertMailSettings(alertInterval = Duration.Zero)

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/CacheGroup.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/CacheGroup.scala
@@ -4,9 +4,11 @@ import com.wordnik.swagger.annotations.ApiModelProperty
 
 import scala.annotation.meta.field
 
-case class CacheGroup(@(ApiModelProperty @field)(required = true) name: String,
-                      @(ApiModelProperty @field)(required = true) owner: String,
-                      @(ApiModelProperty @field)(required = true) description: String)
+case class CacheGroup(
+  @(ApiModelProperty @field)(required = true) name: String,
+  @(ApiModelProperty @field)(required = true) owner: String,
+  @(ApiModelProperty @field)(required = true) description: String
+)
 
 object CacheGroup {
   implicit val order: Ordering[CacheGroup] = Ordering.by(_.name)

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/HttpPartConfig.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/HttpPartConfig.scala
@@ -29,7 +29,8 @@ case class HttpPartConfig(
   @(ApiModelProperty @field)(dataType = "integer", required = false, allowableValues = "range[0, Infinity]", value = "in ms") cacheTtl: Option[FiniteDuration] = Some(Duration.Zero),
   alertMailSettings: AlertMailSettings,
   @(ApiModelProperty @field)(required = true) localContentsEnabled: Boolean = false,
-  @(ApiModelProperty @field)(dataType = "string", required = false) localContents: Option[String] = None)
+  @(ApiModelProperty @field)(dataType = "string", required = false) localContents: Option[String] = None
+)
 
 object HttpPartConfig {
   implicit val order: Ordering[HttpPartConfig] = Ordering.by(_.partId)

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/HystrixConfig.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/HystrixConfig.scala
@@ -5,11 +5,13 @@ import com.wordnik.swagger.annotations.ApiModelProperty
 import scala.annotation.meta.field
 import scala.concurrent.duration.FiniteDuration
 
-case class HystrixConfig(@(ApiModelProperty @field)(required = true, dataType = "integer", value = "in ms") timeout: FiniteDuration,
-                         @(ApiModelProperty @field)(required = true) threadPoolConfig: ThreadPoolConfig,
-                         @(ApiModelProperty @field)(required = true) commandKey: String,
-                         @(ApiModelProperty @field)(required = true) commandGroupKey: String,
-                         @(ApiModelProperty @field)(required = true) localContentsAsFallback: Boolean)
+case class HystrixConfig(
+  @(ApiModelProperty @field)(required = true, dataType = "integer", value = "in ms") timeout: FiniteDuration,
+  @(ApiModelProperty @field)(required = true) threadPoolConfig: ThreadPoolConfig,
+  @(ApiModelProperty @field)(required = true) commandKey: String,
+  @(ApiModelProperty @field)(required = true) commandGroupKey: String,
+  @(ApiModelProperty @field)(required = true) localContentsAsFallback: Boolean
+)
 
 object HystrixConfig {
   implicit val order: Ordering[HystrixConfig] = Ordering.by(_.commandKey)

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/PartParam.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/PartParam.scala
@@ -14,7 +14,8 @@ case class PartParam(
   @(ApiModelProperty @field)(required = true) outputName: String,
   @(ApiModelProperty @field)(required = false, dataType = "string") description: Option[String],
   @(ApiModelProperty @field)(required = false, dataType = "string") inputNameOverride: Option[String],
-  cacheGroups: Set[CacheGroup])
+  cacheGroups: Set[CacheGroup]
+)
 
 object PartParam {
   implicit val order: Ordering[PartParam] = Ordering.by(pp => (pp.outputName, pp.paramType))

--- a/models/src/main/scala/com/m3/octoparts/model/config/json/ThreadPoolConfig.scala
+++ b/models/src/main/scala/com/m3/octoparts/model/config/json/ThreadPoolConfig.scala
@@ -4,6 +4,8 @@ import com.wordnik.swagger.annotations.ApiModelProperty
 
 import scala.annotation.meta.field
 
-case class ThreadPoolConfig(@(ApiModelProperty @field)(required = true) threadPoolKey: String,
-                            @(ApiModelProperty @field)(required = true) coreSize: Int,
-                            @(ApiModelProperty @field)(required = true) queueSize: Int)
+case class ThreadPoolConfig(
+  @(ApiModelProperty @field)(required = true) threadPoolKey: String,
+  @(ApiModelProperty @field)(required = true) coreSize: Int,
+  @(ApiModelProperty @field)(required = true) queueSize: Int
+)

--- a/project/Scalariform.scala
+++ b/project/Scalariform.scala
@@ -5,8 +5,8 @@ object Scalariform {
 
   val settings = scalariformSettings ++ Seq(
     ScalariformKeys.preferences := ScalariformKeys.preferences.value
-      .setPreference(AlignParameters, true)
-      .setPreference(DoubleIndentClassDeclaration, true)
+      //.setPreference(AlignParameters, true)
+      //.setPreference(DoubleIndentClassDeclaration, true)
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.4.0")
 // to show transitive dependencies as a graph
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
 // for code formatting
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 // To check for outdated dependencies (run "sbt dependency-updates")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.2.0")
 // Generate a BuildInfo class

--- a/scala-ws-client/src/main/scala/com/m3/octoparts/ws/AggregateResponseEnrichment.scala
+++ b/scala-ws-client/src/main/scala/com/m3/octoparts/ws/AggregateResponseEnrichment.scala
@@ -12,7 +12,9 @@ import scala.util.{ Failure, Success, Try }
 
 object AggregateResponseEnrichment {
 
-  case class OctopartsException(partResponse: PartResponse) extends RuntimeException(partResponse.errors.mkString(SystemUtils.LINE_SEPARATOR))
+  case class OctopartsException(
+    partResponse: PartResponse
+  ) extends RuntimeException(partResponse.errors.mkString(SystemUtils.LINE_SEPARATOR))
 
   private val logger = Logger("com.m3.octoparts.AggregateResponseEnrichment")
 
@@ -21,7 +23,10 @@ object AggregateResponseEnrichment {
     /**
      * @return The partId and the request-specific id. Used to uniquely identify parts when printing messages.
      */
-    def fullId: String = if (part.id == part.partId) part.id else s"${part.partId} (${part.id})"
+    def fullId: String = {
+      if (part.id == part.partId) part.id
+      else s"${part.partId} (${part.id})"
+    }
 
     /**
      * @return [[PartResponse.contents]] only if there is some non-blank contents.
@@ -84,7 +89,9 @@ object AggregateResponseEnrichment {
   /**
    * Convenience methods to make it easier to work with [[AggregateResponse]]
    */
-  implicit class RichAggregateResponse(val aggResp: AggregateResponse) extends AnyVal {
+  implicit class RichAggregateResponse(
+      val aggResp: AggregateResponse
+  ) extends AnyVal {
 
     /**
      * Extracts the part with the given ID from the Octoparts response and deserializes its JSON content to an [[A]].
@@ -124,14 +131,19 @@ object AggregateResponseEnrichment {
         None
     }
 
-    def getJsonPartOrElse[A: Reads](id: String, default: => A): A = getJsonPart(id).getOrElse(default)
+    def getJsonPartOrElse[A: Reads](id: String, default: => A): A =
+      getJsonPart(id).getOrElse(default)
 
     /**
-     * Deserializes like [[tryJsonPart]], but will try instead to deserialize to an [[E]] if the part response contained errors
+     * Deserializes like [[tryJsonPart]],
+     * but will try instead to deserialize to an [[E]]
+     * if the part response contained errors
      * @tparam A
      * @tparam E
      */
-    def getJsonPartOrError[A: Reads, E: Reads](id: String): Either[Option[E], A] = tryFindPart(id) match {
+    def getJsonPartOrError[A: Reads, E: Reads](
+      id: String
+    ): Either[Option[E], A] = tryFindPart(id) match {
       case Failure(noPart) => {
         logger.warn("Could not retrieve object from response", noPart)
         Left(None)

--- a/scala-ws-client/src/main/scala/com/m3/octoparts/ws/OctoClient.scala
+++ b/scala-ws-client/src/main/scala/com/m3/octoparts/ws/OctoClient.scala
@@ -28,10 +28,12 @@ import com.m3.octoparts.json.format.ConfigModel._ // For serdes of the models
  *                      will result in using the max of this parameter and the timeout on the request (if it exists)
  * @param extraWait Extra margin of wait time for timeouts. Defaults to 50 milliseconds.
  */
-class OctoClient(val client: WSClient,
-                 val baseUrl: String,
-                 protected val clientTimeout: FiniteDuration,
-                 protected val extraWait: FiniteDuration = 50.milliseconds) extends OctoClientLike {
+class OctoClient(
+  val client: WSClient,
+    val baseUrl: String,
+    protected val clientTimeout: FiniteDuration,
+    protected val extraWait: FiniteDuration = 50.milliseconds
+) extends OctoClientLike {
 
   protected def wsRequestFor(url: String, timeout: FiniteDuration) = {
     client.url(url).withRequestTimeout((timeout + extraWait).toMillis.toInt)

--- a/scala-ws-client/src/main/scala/com/m3/octoparts/ws/OctoClient.scala
+++ b/scala-ws-client/src/main/scala/com/m3/octoparts/ws/OctoClient.scala
@@ -29,7 +29,7 @@ import com.m3.octoparts.json.format.ConfigModel._ // For serdes of the models
  * @param extraWait Extra margin of wait time for timeouts. Defaults to 50 milliseconds.
  */
 class OctoClient(
-  val client: WSClient,
+    val client: WSClient,
     val baseUrl: String,
     protected val clientTimeout: FiniteDuration,
     protected val extraWait: FiniteDuration = 50.milliseconds

--- a/scala-ws-client/src/main/scala/com/m3/octoparts/ws/PartRequestEnrichment.scala
+++ b/scala-ws-client/src/main/scala/com/m3/octoparts/ws/PartRequestEnrichment.scala
@@ -19,8 +19,12 @@ object PartRequestEnrichment {
      * the properly formatted body param [[PartRequestParam]] (key of body, and only one)
      */
     def withBody[A: Writeable](body: A): PartRequest = {
-      val bodyAsString = new String(implicitly[Writeable[A]].transform(body), StandardCharsets.UTF_8)
-      val paramsWithBody = partReq.params.filterNot(_.key == BodyParamKey) :+ PartRequestParam(BodyParamKey, bodyAsString)
+      val bodyAsString = new String(
+        implicitly[Writeable[A]].transform(body),
+        StandardCharsets.UTF_8
+      )
+      val paramsWithBody = partReq.params.filterNot(_.key == BodyParamKey) :+
+        PartRequestParam(BodyParamKey, bodyAsString)
       partReq.copy(params = paramsWithBody)
     }
 

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/OctoClientSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/OctoClientSpec.scala
@@ -85,10 +85,12 @@ class OctoClientSpec
         threadPoolConfig = ThreadPoolConfig(
           threadPoolKey = "testThreadPool",
           coreSize = 2,
-          queueSize = 256),
+          queueSize = 256
+        ),
         commandKey = "command",
         commandGroupKey = "GroupKey",
-        localContentsAsFallback = false),
+        localContentsAsFallback = false
+      ),
       additionalValidStatuses = Set(302),
       httpPoolSize = 20,
       httpConnectionTimeout = 1.second,
@@ -103,7 +105,8 @@ class OctoClientSpec
           outputName = "userId",
           inputNameOverride = None,
           cacheGroups = Set.empty
-        )),
+        )
+      ),
       deprecatedInFavourOf = None,
       cacheGroups = Set.empty,
       cacheTtl = Some(60 seconds),
@@ -113,7 +116,8 @@ class OctoClientSpec
         alertPercentThreshold = Some(33.0),
         alertInterval = 10 minutes,
         alertMailRecipients = Some("l-chan@m3.com")
-      ))
+      )
+    )
 
     val mockWSRespPost = jsonAsWSResponse(Json.toJson(mockAggResp))
     val mockWSRespGet = jsonAsWSResponse(Json.toJson(Seq(mockListing)))
@@ -250,7 +254,8 @@ class OctoClientSpec
           implicit val reqMetaB = RequestMetaBuilder.from[Int](i => RequestMeta(id = i.toString))
           Future.sequence(Seq(
             subject.invoke(mockAggReq),
-            subject.invoke(3, Seq(PartRequest("hi")))))
+            subject.invoke(3, Seq(PartRequest("hi")))
+          ))
         }("http://bobby.com/octoparts/2", 2)
       }
 

--- a/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartRequestSpec.scala
+++ b/scala-ws-client/src/test/scala/com/m3/octoparts/ws/RichPartRequestSpec.scala
@@ -13,7 +13,8 @@ class RichPartRequestSpec extends FunSpec with Matchers {
     import PartRequestEnrichment._
     import scala.concurrent.ExecutionContext.Implicits.global
     implicit val tuple3IntWriteable = new Writeable[(Int, Int, Int)](
-      transform = { a => s"${a._1 + a._2 + a._3}".getBytes(StandardCharsets.UTF_8) }, None)
+      transform = { a => s"${a._1 + a._2 + a._3}".getBytes(StandardCharsets.UTF_8) }, None
+    )
 
     it("should add a PartRequestParam with a key of 'body' and a value of whatever the implicit Writeable.transform returns as a string") {
       val pr = PartRequest("hello")

--- a/test/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupportSpec.scala
+++ b/test/com/m3/octoparts/aggregator/service/PartResponseLocalContentSupportSpec.scala
@@ -27,9 +27,11 @@ class PartResponseLocalContentSupportSpec extends FlatSpec
     override implicit def executionContext: ExecutionContext = global
     override def repository: ConfigsRepository = ???
     override def handlerFactory: HttpHandlerFactory = ???
-    override def processWithConfig(ci: HttpPartConfig,
-                                   partRequestInfo: PartRequestInfo,
-                                   params: Map[ShortPartParam, Seq[String]])(implicit parentSpan: Span): Future[PartResponse] = Future(partResponseFromSuper)
+    override def processWithConfig(
+      ci: HttpPartConfig,
+      partRequestInfo: PartRequestInfo,
+      params: Map[ShortPartParam, Seq[String]]
+    )(implicit parentSpan: Span): Future[PartResponse] = Future(partResponseFromSuper)
   }
 
   private val sut = new Super with PartResponseLocalContentSupport
@@ -67,7 +69,8 @@ class PartResponseLocalContentSupportSpec extends FlatSpec
     val fallbackConfig = mockHttpPartConfig.copy(
       localContentsEnabled = false,
       localContents = Some("""{ "hello": "lloyd" }"""),
-      hystrixConfig = Some(mockHystrixConfig.copy(localContentsAsFallback = true, timeout = 500.millis)))
+      hystrixConfig = Some(mockHystrixConfig.copy(localContentsAsFallback = true, timeout = 500.millis))
+    )
     val partRequestInfo = mockPartRequestInfo
     val params = Map.empty[ShortPartParam, Seq[String]]
 

--- a/test/com/m3/octoparts/http/HttpResponseHandlerSpec.scala
+++ b/test/com/m3/octoparts/http/HttpResponseHandlerSpec.scala
@@ -29,7 +29,8 @@ class HttpResponseHandlerSpec extends FunSpec with Matchers with BeforeAndAfter 
     }
     for (body <- httpResp.body) {
       response.setEntity(
-        new ByteArrayEntity(body.getBytes(StandardCharsets.UTF_8), ContentType.create(mimeType, charset)))
+        new ByteArrayEntity(body.getBytes(StandardCharsets.UTF_8), ContentType.create(mimeType, charset))
+      )
     }
 
     for (cookie <- httpResp.cookies) {
@@ -41,7 +42,8 @@ class HttpResponseHandlerSpec extends FunSpec with Matchers with BeforeAndAfter 
 
   val headers = Seq(
     ("header1", "value1"),
-    ("header2", "value2"))
+    ("header2", "value2")
+  )
   val cookie1 = Cookie("session1", "something", true, true, true, -1, None, None)
 
   after {
@@ -62,7 +64,8 @@ class HttpResponseHandlerSpec extends FunSpec with Matchers with BeforeAndAfter 
     val response = buildApacheResponse(
       HttpResponse(HttpStatus.SC_OK, "OK", headers = headers, body = Some("hello world")),
       "application/json",
-      "UTF-8")
+      "UTF-8"
+    )
     it("should return all the headers") {
       handler.handleResponse(response).headers should be(headers)
     }
@@ -79,7 +82,8 @@ class HttpResponseHandlerSpec extends FunSpec with Matchers with BeforeAndAfter 
       val withNullCharset = buildApacheResponse(
         HttpResponse(HttpStatus.SC_OK, "OK", headers = headers, body = Some("hello world")),
         "application/json",
-        null)
+        null
+      )
       handler.handleResponse(withNullCharset).charset should be(None)
     }
 

--- a/test/com/m3/octoparts/hystrix/HystrixExecutorSpec.scala
+++ b/test/com/m3/octoparts/hystrix/HystrixExecutorSpec.scala
@@ -19,11 +19,13 @@ class HystrixExecutorSpec
 
   val noFallbackConfig = mockHttpPartConfig.copy(
     localContents = Some("9"),
-    hystrixConfig = Some(mockHystrixConfig.copy(timeout = 2.seconds)))
+    hystrixConfig = Some(mockHystrixConfig.copy(timeout = 2.seconds))
+  )
 
   val fallbackConfig = mockHttpPartConfig.copy(
     localContents = Some("9"),
-    hystrixConfig = Some(mockHystrixConfig.copy(localContentsAsFallback = true, timeout = 2.seconds)))
+    hystrixConfig = Some(mockHystrixConfig.copy(localContentsAsFallback = true, timeout = 2.seconds))
+  )
 
   describe("#future") {
     it("should return a Future[Result] that makes sense") {

--- a/test/com/m3/octoparts/hystrix/KeyAndBuilderValuesHystrixPropertiesStrategySpec.scala
+++ b/test/com/m3/octoparts/hystrix/KeyAndBuilderValuesHystrixPropertiesStrategySpec.scala
@@ -28,10 +28,12 @@ class KeyAndBuilderValuesHystrixPropertiesStrategySpec extends FunSpec with Matc
 
       val properties1 = HystrixPropertiesFactory.getCommandProperties(
         commandKey,
-        HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(300))
+        HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(300)
+      )
       val properties2 = HystrixPropertiesFactory.getCommandProperties(
         commandKey,
-        HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(600))
+        HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(600)
+      )
       properties1.executionTimeoutInMilliseconds.get should be(300)
       properties2.executionTimeoutInMilliseconds.get should be(600)
     }

--- a/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
+++ b/test/com/m3/octoparts/model/config/HttpPartConfigSpec.scala
@@ -38,10 +38,12 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
           threadPoolConfig = json.ThreadPoolConfig(
             threadPoolKey = "testThreadPool",
             coreSize = 2,
-            queueSize = 256),
+            queueSize = 256
+          ),
           commandKey = "command",
           commandGroupKey = "GroupKey",
-          localContentsAsFallback = false),
+          localContentsAsFallback = false
+        ),
         additionalValidStatuses = Set(302),
         httpPoolSize = 5,
         httpConnectionTimeout = 1.second,
@@ -57,7 +59,8 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
             outputName = "userId",
             inputNameOverride = None,
             cacheGroups = Set.empty
-          )),
+          )
+        ),
         deprecatedInFavourOf = None,
         cacheGroups = Set(mockCacheGroup).map(CacheGroup.toJsonModel),
         cacheTtl = Some(60 seconds),
@@ -69,7 +72,8 @@ class HttpPartConfigSpec extends FunSpec with Matchers with ConfigDataMocks {
           alertMailRecipients = Some("l-chan@m3.com")
         ),
         localContentsEnabled = true,
-        localContents = Some("{}"))
+        localContents = Some("{}")
+      )
       jsonModel should be(expectedModel)
     }
 

--- a/test/com/m3/octoparts/model/config/JsonConversionSpec.scala
+++ b/test/com/m3/octoparts/model/config/JsonConversionSpec.scala
@@ -77,7 +77,8 @@ class JsonConversionSpec extends FunSpec with Matchers with Checkers with Genera
         outputName = outputName,
         description = description,
         inputNameOverride = inputNameOverride,
-        cacheGroups = cacheGroups.toSet)
+        cacheGroups = cacheGroups.toSet
+      )
     }
   }
 

--- a/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
+++ b/test/com/m3/octoparts/repository/config/HttpPartConfigRepositorySpec.scala
@@ -232,7 +232,8 @@ class HttpPartConfigRepositorySpec extends fixture.FunSpec with DBSuite with Mat
         commandGroupKey = "myCommandGroup",
         localContentsAsFallback = false,
         createdAt = DateTime.now,
-        updatedAt = DateTime.now)
+        updatedAt = DateTime.now
+      )
 
     /**
      * Compares two HttpPartConfigs.

--- a/test/controllers/AdminControllerSpec.scala
+++ b/test/controllers/AdminControllerSpec.scala
@@ -56,37 +56,44 @@ class AdminControllerCompanionSpec extends FunSpec with Matchers with ConfigData
     it("should return false if nothing important was changed") {
       AdminController.shouldBustCache(
         mockHttpPartConfig,
-        mockHttpPartConfig.copy(alertMailsEnabled = !mockHttpPartConfig.alertMailsEnabled)) should be(false)
+        mockHttpPartConfig.copy(alertMailsEnabled = !mockHttpPartConfig.alertMailsEnabled)
+      ) should be(false)
     }
     it("should return true if URI was changed ") {
       AdminController.shouldBustCache(
         mockHttpPartConfig,
-        mockHttpPartConfig.copy(uriToInterpolate = s"${mockHttpPartConfig.uriToInterpolate}/whoa")) should be(true)
+        mockHttpPartConfig.copy(uriToInterpolate = s"${mockHttpPartConfig.uriToInterpolate}/whoa")
+      ) should be(true)
     }
     it("should return true if CacheTTL was changed to be shorter") {
       AdminController.shouldBustCache(
         mockHttpPartConfig.copy(cacheTtl = Some(3.second)),
-        mockHttpPartConfig.copy(cacheTtl = Some(2.second))) should be(true)
+        mockHttpPartConfig.copy(cacheTtl = Some(2.second))
+      ) should be(true)
     }
     it("should return true if CacheTTL was changed from None to Some(duration)") {
       AdminController.shouldBustCache(
         mockHttpPartConfig.copy(cacheTtl = None),
-        mockHttpPartConfig.copy(cacheTtl = Some(1.second))) should be(true)
+        mockHttpPartConfig.copy(cacheTtl = Some(1.second))
+      ) should be(true)
     }
     it("should return false if CacheTTL was changed to be longer") {
       AdminController.shouldBustCache(
         mockHttpPartConfig.copy(cacheTtl = Some(3.second)),
-        mockHttpPartConfig.copy(cacheTtl = Some(4.second))) should be(false)
+        mockHttpPartConfig.copy(cacheTtl = Some(4.second))
+      ) should be(false)
     }
     it("should return true if additionalValidStatuses was changed ") {
       AdminController.shouldBustCache(
         mockHttpPartConfig,
-        mockHttpPartConfig.copy(additionalValidStatuses = mockHttpPartConfig.additionalValidStatuses + 911)) should be(true)
+        mockHttpPartConfig.copy(additionalValidStatuses = mockHttpPartConfig.additionalValidStatuses + 911)
+      ) should be(true)
     }
     it("should return true if method was changed ") {
       AdminController.shouldBustCache(
         mockHttpPartConfig,
-        mockHttpPartConfig.copy(method = HttpMethod.values.filter(_ != mockHttpPartConfig.method).firstKey)) should be(true)
+        mockHttpPartConfig.copy(method = HttpMethod.values.filter(_ != mockHttpPartConfig.method).firstKey)
+      ) should be(true)
     }
   }
 
@@ -119,7 +126,8 @@ class AdminControllerSpec
       id = Some(3),
       hystrixConfig = Some(mockHystrixConfig.copy(
         threadPoolConfig = Some(mockThreadConfig),
-        threadPoolConfigId = mockThreadConfig.id))
+        threadPoolConfigId = mockThreadConfig.id
+      ))
     )
   }
 

--- a/test/controllers/AdminFormsSpec.scala
+++ b/test/controllers/AdminFormsSpec.scala
@@ -39,10 +39,12 @@ class AdminFormsSpec extends FunSpec with Matchers with ConfigDataMocks {
         interval = None,
         absoluteThreshold = None,
         percentThreshold = None,
-        recipients = None),
+        recipients = None
+      ),
       localContentsConfig = LocalContentsConfig(
         enabled = false,
-        contents = None)
+        contents = None
+      )
     )
 
     describe("#toNewHttpPartConfig") {

--- a/test/controllers/support/AuthorizationCheckSupportSpec.scala
+++ b/test/controllers/support/AuthorizationCheckSupportSpec.scala
@@ -21,7 +21,8 @@ class AuthorizationCheckSupportSpec extends FlatSpec with Matchers with PlayAppS
     andThen(authenticationCheckFilter(_ => Future.successful(Unauthorized))).
     andThen(authorizationCheckFilter(
       req => Future.successful(req.principal.roles.toSet.intersect(acceptedRoles).nonEmpty),
-      _ => Future.successful(Forbidden))).
+      _ => Future.successful(Forbidden)
+    )).
     apply(req => Ok(s"Hi, ${req.principal.nickname}"))
 
   it should "forbid an unauthorized user" in {

--- a/test/controllers/system/SystemConfigControllerSpec.scala
+++ b/test/controllers/system/SystemConfigControllerSpec.scala
@@ -21,7 +21,8 @@ class SystemConfigControllerSpec
       """
         |foo.bar = "a"
         |foo.baz = 123
-      """.stripMargin)
+      """.stripMargin
+    )
     val controller = new SystemConfigController(config)
     val result = controller.showSystemConfig.apply(FakeRequest())
     toLines(contentAsString(result)) should equal(toLines(
@@ -30,7 +31,8 @@ class SystemConfigControllerSpec
         |        "bar" : "a",
         |        "baz" : 123
         |    }
-        |}"""))
+        |}"""
+    ))
   }
 
   it should "try its best to mask passwords" in {
@@ -40,7 +42,8 @@ class SystemConfigControllerSpec
         |foo.baz.bing.hoge = "hello"
         |foo.baz.bing.password = "another secret"
         |foo.password.wow = "don't mask me!"
-      """.stripMargin)
+      """.stripMargin
+    )
     val controller = new SystemConfigController(config)
     val result = controller.showSystemConfig.apply(FakeRequest())
     checkJson(result) {

--- a/test/integration/PagesSupport.scala
+++ b/test/integration/PagesSupport.scala
@@ -60,12 +60,14 @@ trait PagesSupport { this: OneDIBrowserPerSuite with PlayServerSupport =>
 
   object PartAddPage extends SeleniumPage {
 
-    case class PartConfig(partId: String,
-                          url: String,
-                          connectionPoolSize: Int,
-                          commandKey: String,
-                          commandKeyGroup: String,
-                          proxy: Option[String])
+    case class PartConfig(
+      partId: String,
+      url: String,
+      connectionPoolSize: Int,
+      commandKey: String,
+      commandKeyGroup: String,
+      proxy: Option[String]
+    )
 
     val url: String = s"$baseUrl/admin/parts/new"
 


### PR DESCRIPTION
This pull request contains the following changes.
- bump sbt-scalariform version to 1.6.0 (latest)
- apply scalariform with the rules defined in `project/Scalariform.scala`
- apply scalariform to not only Play app but also other sub-projects as well
- manually modify some code to make them more readable

I believe the changes improve the readability of code.
